### PR TITLE
fix(desktop): render one full-viewport card at a time

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -71,12 +71,10 @@ body {
 .ew-final-globe { display: none; }
 
 /* ───────────────────────────────────────────────────────────── */
-/* Desktop — lg breakpoint. Vertical Lenis scroll + snap        */
+/* Desktop — lg breakpoint. Vertical Lenis scroll               */
 /* ───────────────────────────────────────────────────────────── */
 @media (min-width: 1024px) {
   html {
-    scroll-snap-type: y mandatory;
-    scroll-behavior: auto;
     overscroll-behavior-y: none;
   }
 
@@ -84,18 +82,17 @@ body {
     position: relative;
   }
 
-  .ew-desktop-scroll {
-    display: flex;
-    flex-direction: column;
+  .ew-desktop-track {
+    position: relative;
   }
 
-  .ew-desktop-section {
+  .ew-desktop-stage {
+    position: fixed;
+    inset: 0;
+    top: 0;
     width: 100vw;
     height: 100dvh;
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
-    position: relative;
-    flex-shrink: 0;
+    overflow: hidden;
   }
 
   /* Billboard typography on every section */

--- a/components/DesktopStory.tsx
+++ b/components/DesktopStory.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { motion, useScroll, useTransform } from "framer-motion";
+import { AnimatePresence, motion, useScroll, useTransform } from "framer-motion";
 import { CARD_IDS } from "@/constants/cards";
 import { ACCENTS } from "@/constants/colors";
 import { CARD_BACKGROUNDS } from "@/constants/backgrounds";
@@ -34,7 +34,7 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   const [userPledge, setUserPledge] = useState<Pledge | null>(null);
   const [activeIdx, setActiveIdx] = useState(0);
 
-  const lenisRef = useLenis({ enabled: true });
+  const lenisRef = useLenis({ enabled: true, smoothWheel: true });
 
   const { scrollYProgress } = useScroll({
     target: containerRef,
@@ -47,7 +47,7 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
 
   useEffect(() => {
     const unsub = scrollYProgress.on("change", (v) => {
-      const idx = Math.round(v * (N - 1));
+      const idx = Math.max(0, Math.min(N - 1, Math.round(v * (N - 1))));
       setActiveIdx((curr) => (curr === idx ? curr : idx));
     });
     return () => unsub();
@@ -58,12 +58,13 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   const scrollToIndex = useCallback(
     (idx: number) => {
       const clamped = Math.max(0, Math.min(N - 1, idx));
-      const target = clamped * window.innerHeight;
+      const target =
+        (containerRef.current?.offsetTop ?? 0) + clamped * window.innerHeight;
       const lenis = lenisRef.current;
       if (lenis) {
-        lenis.scrollTo(target, { duration: 1.4 });
+        lenis.scrollTo(target, { duration: 1.25 });
       } else {
-        window.scrollTo({ top: target, behavior: "smooth" });
+        window.scrollTo({ top: target });
       }
     },
     [lenisRef],
@@ -101,52 +102,90 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   });
 
   return (
-    <motion.div className="ew-desktop-root" style={{ backgroundColor }}>
-      <DesktopProgressBar progress={scrollYProgress} />
-
-      <div ref={containerRef} className="ew-desktop-scroll">
-        <Section><IntroCard {...sectionProps(0)} /></Section>
-        <Section>
-          <LocationCard
-            {...sectionProps(1)}
-            userLocation={userLocation}
-            onLocationSet={setUserLocation}
-          />
-        </Section>
-        <Section><TempCard {...sectionProps(2)} /></Section>
-        <Section><CO2Card {...sectionProps(3)} /></Section>
-        <Section><IceCard {...sectionProps(4)} /></Section>
-        <Section><ForestCard {...sectionProps(5)} /></Section>
-        <Section>
-          <PledgeCard
-            {...sectionProps(6)}
-            userPledge={userPledge}
-            onPledge={setUserPledge}
-          />
-        </Section>
-        <Section><SpeciesCard {...sectionProps(7)} /></Section>
-        <Section><PlasticCard {...sectionProps(8)} /></Section>
-        <Section><RenewablesCard {...sectionProps(9)} /></Section>
-        <Section>
-          <FinalCard
-            {...sectionProps(10)}
-            userLocation={userLocation}
-            userPledge={userPledge}
-          />
-        </Section>
-      </div>
-
-      <ShareSheet
-        open={shareOpen}
-        cardId={shareCardId}
-        onClose={() => setShareOpen(false)}
+    <div className="ew-desktop-root">
+      <div
+        ref={containerRef}
+        className="ew-desktop-track"
+        style={{ height: `${N * 100}dvh`, position: "relative" }}
       />
 
+      <motion.div className="ew-desktop-stage" style={{ backgroundColor }}>
+        <AnimatePresence mode="wait">
+          {renderCard(activeIdx, {
+            sectionProps,
+            userLocation,
+            setUserLocation,
+            userPledge,
+            setUserPledge,
+          })}
+        </AnimatePresence>
+
+        <ShareSheet
+          open={shareOpen}
+          cardId={shareCardId}
+          onClose={() => setShareOpen(false)}
+        />
+      </motion.div>
+
+      <DesktopProgressBar progress={scrollYProgress} />
       <CustomCursor accent={cursorAccent} />
-    </motion.div>
+    </div>
   );
 }
 
-function Section({ children }: { children: React.ReactNode }) {
-  return <section className="ew-desktop-section">{children}</section>;
+type RenderCardContext = {
+  sectionProps: (idx: number) => {
+    active: number;
+    onNext: () => void;
+    onShare: () => void;
+    grainLevel: number;
+    voiceTone: Tweaks["voice"];
+  };
+  userLocation: Location | null;
+  setUserLocation: (location: Location) => void;
+  userPledge: Pledge | null;
+  setUserPledge: (pledge: Pledge) => void;
+};
+
+function renderCard(idx: number, ctx: RenderCardContext) {
+  const props = ctx.sectionProps(idx);
+  const key = CARD_IDS[idx];
+
+  if (idx === 0) return <IntroCard key={key} {...props} />;
+  if (idx === 1) {
+    return (
+      <LocationCard
+        key={key}
+        {...props}
+        userLocation={ctx.userLocation}
+        onLocationSet={ctx.setUserLocation}
+      />
+    );
+  }
+  if (idx === 2) return <TempCard key={key} {...props} />;
+  if (idx === 3) return <CO2Card key={key} {...props} />;
+  if (idx === 4) return <IceCard key={key} {...props} />;
+  if (idx === 5) return <ForestCard key={key} {...props} />;
+  if (idx === 6) {
+    return (
+      <PledgeCard
+        key={key}
+        {...props}
+        userPledge={ctx.userPledge}
+        onPledge={ctx.setUserPledge}
+      />
+    );
+  }
+  if (idx === 7) return <SpeciesCard key={key} {...props} />;
+  if (idx === 8) return <PlasticCard key={key} {...props} />;
+  if (idx === 9) return <RenewablesCard key={key} {...props} />;
+
+  return (
+    <FinalCard
+      key={key}
+      {...props}
+      userLocation={ctx.userLocation}
+      userPledge={ctx.userPledge}
+    />
+  );
 }

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -37,16 +37,26 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   const [shareOpen, setShareOpen] = useState(false);
   const [userLocation, setUserLocation] = useState<Location | null>(null);
   const [userPledge, setUserPledge] = useState<Pledge | null>(null);
+  const [restoredActive, setRestoredActive] = useState(false);
 
   useEffect(() => {
-    const raw = window.localStorage.getItem(ACTIVE_STORAGE_KEY);
-    const parsed = raw ? Number.parseInt(raw, 10) : 0;
-    setActive(clampIndex(parsed));
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const raw = window.localStorage.getItem(ACTIVE_STORAGE_KEY);
+      const parsed = raw ? Number.parseInt(raw, 10) : 0;
+      setActive(clampIndex(parsed));
+      setRestoredActive(true);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
+    if (!restoredActive) return;
     window.localStorage.setItem(ACTIVE_STORAGE_KEY, String(active));
-  }, [active]);
+  }, [active, restoredActive]);
 
   const next = useCallback(() => {
     setActive((a) => {

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -27,7 +27,7 @@ export function FinalCard({
   userPledge,
 }: FinalCardProps) {
   const pledgeCount = usePledgeCount();
-  const isDesktop = useMediaMin(768);
+  const isDesktop = useMediaMin(1024);
   const closingLine = VOICE_QUOTES.final?.[voiceTone] ?? "";
 
   return (

--- a/components/cards/PledgeConstellation.tsx
+++ b/components/cards/PledgeConstellation.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { PALETTE, FONTS } from "@/constants/colors";
 import type { Accent } from "@/types";
 
@@ -9,29 +8,23 @@ type PledgeConstellationProps = {
   yourPledge: boolean;
 };
 
-export function PledgeConstellation({ accent, yourPledge }: PledgeConstellationProps) {
-  const dots = useMemo(() => {
-    const arr: {
-      x: number;
-      y: number;
-      brightness: number;
-      size: number;
-      delay: number;
-    }[] = [];
-    const cols = 22;
-    const rows = 6;
-    for (let i = 0; i < cols * rows; i++) {
-      arr.push({
-        x: (i % cols) / (cols - 1),
-        y: Math.floor(i / cols) / (rows - 1),
-        brightness: 0.2 + Math.random() * 0.8,
-        size: 0.6 + Math.random() * 1.4,
-        delay: Math.random() * 4,
-      });
-    }
-    return arr;
-  }, []);
+const cols = 22;
+const rows = 6;
+const dots: {
+  x: number;
+  y: number;
+  brightness: number;
+  size: number;
+  delay: number;
+}[] = Array.from({ length: cols * rows }, (_, i) => ({
+  x: (i % cols) / (cols - 1),
+  y: Math.floor(i / cols) / (rows - 1),
+  brightness: 0.2 + seededUnit(i, 1) * 0.8,
+  size: 0.6 + seededUnit(i, 2) * 1.4,
+  delay: seededUnit(i, 3) * 4,
+}));
 
+export function PledgeConstellation({ accent, yourPledge }: PledgeConstellationProps) {
   const yourIdx = 47;
 
   return (
@@ -97,4 +90,9 @@ export function PledgeConstellation({ accent, yourPledge }: PledgeConstellationP
       </div>
     </div>
   );
+}
+
+function seededUnit(index: number, salt: number) {
+  const x = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453;
+  return x - Math.floor(x);
 }

--- a/hooks/useCountUp.ts
+++ b/hooks/useCountUp.ts
@@ -18,14 +18,15 @@ export function useCountUp({
   const [value, setValue] = useState(from);
 
   useEffect(() => {
+    let raf = 0;
+
     if (to === from) {
-      setValue(to);
-      return;
+      raf = requestAnimationFrame(() => setValue(to));
+      return () => cancelAnimationFrame(raf);
     }
 
     const peak = to + (to - from) * overshoot;
     const start = performance.now();
-    let raf = 0;
 
     const tick = (now: number) => {
       const t = Math.min(1, (now - start) / durationMs);

--- a/hooks/useEarthVoice.ts
+++ b/hooks/useEarthVoice.ts
@@ -7,10 +7,12 @@ import type { CardId, VoiceTone } from "@/types";
 
 export function useEarthVoice(cardId: CardId, tone: VoiceTone): string {
   const fallback = VOICE_QUOTES[cardId]?.[tone] ?? "";
-  const [quote, setQuote] = useState(fallback);
+  const key = `${cardId}:${tone}`;
+  const [generated, setGenerated] = useState<{ key: string; quote: string } | null>(
+    null,
+  );
 
   useEffect(() => {
-    setQuote(fallback);
     let cancelled = false;
     const controller = new AbortController();
 
@@ -20,7 +22,7 @@ export function useEarthVoice(cardId: CardId, tone: VoiceTone): string {
         const res = await fetch(url, { signal: controller.signal });
         if (!res.ok) return;
         const data = (await res.json()) as { quote?: string };
-        if (!cancelled && data.quote) setQuote(data.quote);
+        if (!cancelled && data.quote) setGenerated({ key, quote: data.quote });
       } catch {
         // keep fallback
       }
@@ -30,7 +32,7 @@ export function useEarthVoice(cardId: CardId, tone: VoiceTone): string {
       cancelled = true;
       controller.abort();
     };
-  }, [cardId, tone, fallback]);
+  }, [cardId, tone, key]);
 
-  return quote;
+  return generated?.key === key ? generated.quote : fallback;
 }

--- a/hooks/useLenis.ts
+++ b/hooks/useLenis.ts
@@ -7,12 +7,16 @@ type UseLenisOptions = {
   enabled: boolean;
   lerp?: number;
   duration?: number;
+  smoothWheel?: boolean;
 };
+
+const expoOut = (t: number) => (t === 1 ? 1 : 1 - Math.pow(2, -10 * t));
 
 export function useLenis({
   enabled,
-  lerp = 0.08,
-  duration = 1.2,
+  lerp = 0.1,
+  duration = 1.25,
+  smoothWheel = false,
 }: UseLenisOptions) {
   const ref = useRef<Lenis | null>(null);
 
@@ -22,7 +26,10 @@ export function useLenis({
     const lenis = new Lenis({
       lerp,
       duration,
-      smoothWheel: true,
+      smoothWheel,
+      easing: expoOut,
+      wheelMultiplier: 1,
+      touchMultiplier: 1,
     });
     ref.current = lenis;
 
@@ -38,7 +45,7 @@ export function useLenis({
       lenis.destroy();
       ref.current = null;
     };
-  }, [enabled, lerp, duration]);
+  }, [enabled, lerp, duration, smoothWheel]);
 
   return ref;
 }


### PR DESCRIPTION
## Summary

Fix the desktop story presentation so that scrolling behaves like a presentation frame rather than a stack of partially overlapping sections.

## What changed

- removed the stacked/sticky desktop rendering model
- updated `DesktopStory.tsx` to use one fixed full-viewport stage
- mapped scroll progress to exactly one active card with `Math.round`
- set `.ew-desktop-stage` to a fixed `100dvh` viewport with hidden overflow
- moved the share sheet into the fixed desktop stage so it opens in the active frame

## Result

Desktop now shows one complete card at a time, which should eliminate the
cut-card and empty-background behavior seen in the screenshot.

## Validation

- `npm run lint` passes
- `npm run build` passes