### PR TITLE
fix(desktop): restore card visibility in fixed presentation stage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -93,6 +93,7 @@ body {
     width: 100vw;
     height: 100dvh;
     overflow: hidden;
+    z-index: 1;
   }
 
   /* Billboard typography on every section */

--- a/components/DesktopStory.tsx
+++ b/components/DesktopStory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AnimatePresence, motion, useScroll, useTransform } from "framer-motion";
 import { CARD_IDS } from "@/constants/cards";
 import { ACCENTS } from "@/constants/colors";
@@ -27,7 +27,6 @@ type DesktopStoryProps = { tweaks: Tweaks };
 const N = CARD_IDS.length;
 
 export function DesktopStory({ tweaks }: DesktopStoryProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const [shareOpen, setShareOpen] = useState(false);
   const [shareCardId, setShareCardId] = useState<CardId>("intro");
   const [userLocation, setUserLocation] = useState<Location | null>(null);
@@ -36,10 +35,7 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
 
   const lenisRef = useLenis({ enabled: true, smoothWheel: true });
 
-  const { scrollYProgress } = useScroll({
-    target: containerRef,
-    offset: ["start start", "end end"],
-  });
+  const { scrollYProgress } = useScroll();
 
   const stops = CARD_IDS.map((_, i) => i / (N - 1));
   const bgStops = CARD_IDS.map((id) => CARD_BACKGROUNDS[id]);
@@ -58,8 +54,7 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   const scrollToIndex = useCallback(
     (idx: number) => {
       const clamped = Math.max(0, Math.min(N - 1, idx));
-      const target =
-        (containerRef.current?.offsetTop ?? 0) + clamped * window.innerHeight;
+      const target = clamped * window.innerHeight;
       const lenis = lenisRef.current;
       if (lenis) {
         lenis.scrollTo(target, { duration: 1.25 });
@@ -104,7 +99,6 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   return (
     <div className="ew-desktop-root">
       <div
-        ref={containerRef}
         className="ew-desktop-track"
         style={{ height: `${N * 100}dvh`, position: "relative" }}
       />

--- a/components/cards/CardShell.tsx
+++ b/components/cards/CardShell.tsx
@@ -56,9 +56,7 @@ export function CardShell({
       key={cardId}
       variants={cardEnter}
       initial="hidden"
-      animate={isDesktop ? undefined : "visible"}
-      whileInView={isDesktop ? "visible" : undefined}
-      viewport={isDesktop ? { once: true, amount: 0.3 } : undefined}
+      animate="visible"
       exit="hidden"
       transition={{ duration: 0.5, ease: [0.2, 0.8, 0.2, 1] }}
       onClick={effectiveClickable ? onNext : undefined}

--- a/components/cards/StatBlock.tsx
+++ b/components/cards/StatBlock.tsx
@@ -56,8 +56,7 @@ export function StatBlock({
     >
       <motion.div
         initial={{ opacity: 0, scale: 0.96 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        viewport={{ once: true, amount: 0.4 }}
+        animate={{ opacity: 1, scale: 1 }}
         transition={{ duration: 0.8, ease: [0.2, 0.8, 0.2, 1] }}
         style={{
           position: "relative",

--- a/components/ui/CardTypography.tsx
+++ b/components/ui/CardTypography.tsx
@@ -47,8 +47,7 @@ export function EarthQuote({
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.5 }}
+      animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 1, ease: [0.2, 0.8, 0.2, 1], delay: 0.3 }}
       style={style}
     >


### PR DESCRIPTION
## Summary

Fix a desktop regression where cards could disappear after switching the story to the fixed presentation-stage model.

## Root cause

The desktop flow no longer used real stacked viewport sections, but several
card/content animations still depended on `whileInView`. In the fixed-stage
layout, those observers could leave the card shell or major content stuck at
`opacity: 0`.

## What changed

- updated `DesktopStory.tsx` to use document scroll progress directly
- set the fixed desktop stage above the spacer with `z-index: 1`
- made `CardShell` animate visible when mounted
- removed viewport-observer dependence from primary stat/text content in
  `StatBlock.tsx` and `CardTypography.tsx`

## Validation

- `npm run lint` passes
- `npm run build` passes