### PR TITLE
feat(share): personalize the poster and restore staggered quote/stats…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,96 @@
 # Earth Wrapped · MMXXVI
 
-A letter from the planet. Eleven cards. One year. Signed, Earth.
+Earth is the user. 2026 is the year being reviewed.
 
-Interactive year-in-review experience delivered as an 11-card story: global temperature anomaly, atmospheric CO₂, ice loss, forest loss, biodiversity, plastic, renewables — plus interactive cards for location, pledges (minted to an on-chain ledger), and a closing constellation of everyone who read tonight.
+`thisyear.earth` is an immersive climate year-in-review told as eleven full-screen chapters. It borrows the emotional grammar of a wrapped recap, but the narrator is Earth: ancient, factual, dry, tired, and still here.
+
+## Experience
+
+The site moves through eleven chapters:
+
+1. **Preface · The Record**
+2. **Chapter II · Coordinates**
+3. **Chapter III · The Fever**
+4. **Chapter IV · The Atmosphere**
+5. **Chapter V · The Melt**
+6. **Chapter VI · The Canopy**
+7. **Chapter VII · The Ledger**
+8. **Chapter VIII · The Roll Call**
+9. **Chapter IX · The Residue**
+10. **Chapter X · The Turn**
+11. **Epilogue · Sincerely**
+
+Mobile is a native-feeling card experience: swipe, tap, pledge, share.
+
+Desktop is a cinematic scroll experience: one chapter per viewport, Lenis smooth scroll, billboard-scale numbers, and pinned story beats.
 
 ## Stack
 
-- **Next.js 16** (app router, Turbopack, React 19)
-- **TypeScript** (strict)
+- **Next.js 16** with the App Router
+- **React 19**
+- **TypeScript strict**
 - **Tailwind CSS v4**
-- **Framer Motion** — every animation
-- **Neon** (`@neondatabase/serverless`) — pledges + locations
-- **Solana** (stubbed) — pledge tx hashes
-- **Gemini** — dynamic Earth quotes (optional, falls back to static lines)
+- **Framer Motion**
+- **Lenis** for desktop smooth scroll
+- **NOAA GML** daily Mauna Loa CO₂ data
+- **Neon** for pledge data
+- **Solana memo transactions** for the pledge ledger
+- **globe.gl / three-globe assets** for the final reader globe
 
-## Quick start
+## Local Development
 
 ```bash
 npm install
-npm run dev        # http://localhost:3000
+npm run dev
 ```
 
-### Environment
+The dev server runs at:
 
-All optional — app runs fully without them (fallback data, in-memory store, stub tx hashes).
+```text
+http://localhost:3000
+```
+
+## Environment
+
+The app can run without environment variables. Missing services fall back to local or stubbed behavior where possible.
 
 ```bash
-# .env.local
-GEMINI_API_KEY=...        # enables tone-variant quotes via /api/earth-voice
-DATABASE_URL=postgres://... # Neon connection string for pledges + locations
+GEMINI_API_KEY=...
+DATABASE_URL=postgres://...
 ```
 
-## Project structure
+`GEMINI_API_KEY` enables generated one-sentence Earth voice copy through `/api/earth-voice`.
 
-```
-app/                  routes + API handlers
-  api/co2/            server-side NOAA Mauna Loa fetch
-  api/earth-voice/    Gemini proxy (tone-variant quotes)
-  api/pledges/        GET count · POST mint
-components/
-  cards/              one file per card — all use CardShell
-  ui/                 CardShell, ProgressBar, ShareSheet, MintButton, SwipeContainer
-  Story.tsx           orchestrator (nav, swipe, keyboard, persistence)
-constants/            card ids, colors, animation variants, endpoints, copy
-hooks/                useSwipe, useCountUp, useLocation, useEarthVoice, useCo2, usePledge
-lib/
-  api/                co2.ts, gemini.ts (server-only)
-  db/                 Neon clients — pledges.ts, locations.ts
-  solana/             mint.ts (stubbed tx hashes)
-types/                shared types with barrel index — CardId, Accent, Location, Pledge, ClimateData, CardData, Tweaks, VoiceTone
-config/site.ts        site metadata
-```
-
-## Conventions
-
-- Components never call APIs directly — always through hooks.
-- `lib/` is pure TypeScript, no React.
-- All magic strings live in `constants/`; all external URLs in `constants/endpoints.ts`.
-- Gemini calls proxied through `app/api/earth-voice/route.ts`. CO₂ fetched server-side via `app/api/co2/route.ts`.
-- Every card uses `CardShell`. Single responsibility per file.
-- Shared types (used in >1 file) live in `types/` with a barrel. Single-use types colocate in the file that owns them.
-- Component prop types are named `{ComponentName}Props` — never a generic `Props`.
+`DATABASE_URL` enables persistent pledge counts and pledge records through Neon.
 
 ## Scripts
 
 ```bash
-npm run dev     # dev server
-npm run build   # production build + type check
-npm start       # run production build
-npm run lint    # eslint
+npm run dev
+npm run build
+npm start
+npm run lint
 ```
 
-## Navigation
+## Data
 
-- `←` / `→` · arrow keys
-- `space` · advance
-- swipe on touch
-- tap sides (on stat cards)
-- interactive cards: location, pledge, final — advance via in-card button
+The CO₂ chapter reads NOAA GML daily Mauna Loa data server-side and caches the response. The card uses the latest reading, year-to-date high, year-to-date average, long-term delta, and a subtle sparkline.
+
+Other climate figures are presented as editorial chapter data inside the experience:
+
+- global temperature anomaly
+- ice loss
+- forest loss
+- species threatened
+- plastic production
+- renewable energy growth
+
+## Ledger
+
+The pledge chapter asks for one small action for next year. The product language for the Solana interaction is:
+
+```text
+MINT TO THE LEDGER
+```
+
+Pledges can be stored through Neon and represented with a Solana memo transaction hash.

--- a/app/globals.css
+++ b/app/globals.css
@@ -143,6 +143,10 @@ body {
     display: none !important;
   }
 
+  .ew-desktop-root [data-card="final"] .ew-card-next {
+    display: flex !important;
+  }
+
   .ew-desktop-root .ew-share-button {
     position: relative;
     z-index: 60;

--- a/components/DesktopStory.tsx
+++ b/components/DesktopStory.tsx
@@ -79,14 +79,14 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
   const cursorAccent = ACCENTS[CARD_IDS[activeIdx]];
 
   const scrollToIndex = useCallback(
-    (idx: number) => {
+    (idx: number, immediate = false) => {
       const clamped = Math.max(0, Math.min(N - 1, idx));
       const target = clamped * window.innerHeight;
       const lenis = lenisRef.current;
       if (lenis) {
-        lenis.scrollTo(target, { duration: 1.25 });
+        lenis.scrollTo(target, immediate ? { immediate: true } : { duration: 1.25 });
       } else {
-        window.scrollTo({ top: target });
+        window.scrollTo({ top: target, behavior: immediate ? "instant" : "auto" });
       }
     },
     [lenisRef],
@@ -117,7 +117,7 @@ export function DesktopStory({ tweaks }: DesktopStoryProps) {
 
   const sectionProps = (idx: number) => ({
     active: idx,
-    onNext: () => scrollToIndex(idx + 1),
+    onNext: () => scrollToIndex(idx >= N - 1 ? 0 : idx + 1, idx >= N - 1),
     onShare: () => openShare(CARD_IDS[idx]),
     grainLevel: tweaks.grain,
     voiceTone: tweaks.voice,

--- a/components/cards/CardShell.tsx
+++ b/components/cards/CardShell.tsx
@@ -72,6 +72,7 @@ export function CardShell({
         onShare={onShare}
         onNext={onNext}
         label={nextLabel}
+        hideShare={cardId !== "final"}
         hideNext={hideNext}
       />
     </motion.div>

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -5,7 +5,6 @@ import type { CardCommonProps, Location, Pledge } from '@/types';
 import { VOICE_QUOTES } from '@/constants/quotes';
 import { CardShell } from './CardShell';
 import { FinalGlobe } from './FinalGlobe';
-import { HorizonLine } from '@/components/ui/CardTypography';
 import { usePledgeCount } from '@/hooks/usePledge';
 
 type FinalCardProps = CardCommonProps & {
@@ -135,8 +134,6 @@ export function FinalCard({
           </div>
         )}
       </div>
-
-      <HorizonLine accent={accent} bottom={138} />
 
       <div
         style={{

--- a/components/cards/RenewablesCard.tsx
+++ b/components/cards/RenewablesCard.tsx
@@ -1,17 +1,27 @@
-"use client";
+'use client';
 
-import { FONTS, ACCENTS } from "@/constants/colors";
-import type { CardCommonProps } from "@/types";
-import { CardShell } from "./CardShell";
-import { StatBlock, StatLadder, StatSourceMeta } from "./StatBlock";
-import { EarthQuote, StatLabel, HorizonLine } from "@/components/ui/CardTypography";
-import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
-import { useEarthVoice } from "@/hooks/useEarthVoice";
+import { FONTS, ACCENTS } from '@/constants/colors';
+import type { CardCommonProps } from '@/types';
+import { CardShell } from './CardShell';
+import { StatBlock, StatLadder, StatSourceMeta } from './StatBlock';
+import {
+  EarthQuote,
+  StatLabel,
+  HorizonLine,
+} from '@/components/ui/CardTypography';
+import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
+import { useEarthVoice } from '@/hooks/useEarthVoice';
 
 const accent = ACCENTS.renewables;
 
-export function RenewablesCard({ active, onNext, onShare, grainLevel, voiceTone }: CardCommonProps) {
-  const quote = useEarthVoice("renewables", voiceTone);
+export function RenewablesCard({
+  active,
+  onNext,
+  onShare,
+  grainLevel,
+  voiceTone,
+}: CardCommonProps) {
+  const quote = useEarthVoice('renewables', voiceTone);
 
   return (
     <CardShell
@@ -23,16 +33,16 @@ export function RenewablesCard({ active, onNext, onShare, grainLevel, voiceTone 
     >
       <div
         style={{
-          position: "absolute",
+          position: 'absolute',
           top: 170,
           left: 0,
           right: 0,
-          textAlign: "center",
+          textAlign: 'center',
           zIndex: 10,
           fontFamily: FONTS.MONO,
           fontSize: 10,
-          letterSpacing: "0.3em",
-          textTransform: "uppercase",
+          letterSpacing: '0.3em',
+          textTransform: 'uppercase',
           color: accent.hex,
           fontWeight: 500,
         }}
@@ -47,20 +57,24 @@ export function RenewablesCard({ active, onNext, onShare, grainLevel, voiceTone 
         desktopFontSize="clamp(380px, 40vw, 520px)"
         translateY={-10}
       >
-        <span style={{ color: accent.hex, fontSize: "0.5em", verticalAlign: "top" }}>+</span>
+        <span
+          style={{ color: accent.hex, fontSize: '0.5em', verticalAlign: 'top' }}
+        >
+          +
+        </span>
         <AnimatedNumber value={32} />
-        <span style={{ color: accent.hex, fontSize: "0.5em" }}>%</span>
+        <span style={{ color: accent.hex, fontSize: '0.5em' }}>%</span>
       </StatBlock>
 
       <svg
         style={{
-          position: "absolute",
+          position: 'absolute',
           bottom: 195,
           left: 40,
           right: 40,
           height: 44,
           zIndex: 8,
-          pointerEvents: "none",
+          pointerEvents: 'none',
         }}
         viewBox="0 0 310 44"
         preserveAspectRatio="none"
@@ -82,17 +96,17 @@ export function RenewablesCard({ active, onNext, onShare, grainLevel, voiceTone 
         accent={accent}
         top={260}
         rows={[
-          { left: "— SOLAR", right: "· +42%" },
-          { left: "— WIND", right: "· +18%" },
-          { left: "— BATTERIES", right: "· +76%" },
-          { left: "— EV SALES", right: "· +24%" },
-          { left: "— COAL", right: "· −3%", active: true },
+          { left: '— SOLAR', right: '· +42%' },
+          { left: '— WIND', right: '· +18%' },
+          { left: '— BATTERIES', right: '· +76%' },
+          { left: '— EV SALES', right: '· +24%' },
+          { left: '— COAL', right: '· −3%', active: true },
         ]}
       />
       <StatSourceMeta
         top={260}
-        rows={["SRC: IEA", "SRC: IRENA"]}
-        dim={["CAPACITY ADDED", "YOY · GW"]}
+        rows={['SRC: IEA', 'SRC: IRENA']}
+        dim={['CAPACITY ADDED', 'YOY · GW']}
       />
 
       <StatLabel>The energy you chose</StatLabel>

--- a/components/ui/CardChrome.tsx
+++ b/components/ui/CardChrome.tsx
@@ -10,6 +10,7 @@ type CardChromeProps = {
   onShare?: () => void;
   onNext?: () => void;
   label?: string;
+  hideShare?: boolean;
   hideNext?: boolean;
 };
 
@@ -17,6 +18,7 @@ export function CardChrome({
   onShare,
   onNext,
   label = "Next",
+  hideShare = false,
   hideNext = false,
 }: CardChromeProps) {
   return (
@@ -34,39 +36,50 @@ export function CardChrome({
           padding: "0 24px",
         }}
       >
-        <button
-          type="button"
-          className="ew-share-button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onShare?.();
-          }}
-          style={{
-            all: "unset",
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: 7,
-            padding: "9px 13px",
-            borderRadius: 99,
-            background: "rgba(230, 214, 190, 0.06)",
-            border: "1px solid rgba(230, 214, 190, 0.14)",
-            backdropFilter: "blur(6px)",
-            fontFamily: FONTS.MONO,
-            fontSize: 9.5,
-            letterSpacing: "0.22em",
-            textTransform: "uppercase",
-            color: PALETTE.ASH_DIM,
-            fontWeight: 500,
-          }}
-        >
-          <ShareIcon size={12} color={PALETTE.ASH_DIM} />
-          Share
-        </button>
+        {!hideShare && (
+          <button
+            type="button"
+            className="ew-share-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onShare?.();
+            }}
+            style={{
+              all: "unset",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              gap: 7,
+              padding: "9px 13px",
+              borderRadius: 99,
+              background: "rgba(230, 214, 190, 0.06)",
+              border: "1px solid rgba(230, 214, 190, 0.14)",
+              backdropFilter: "blur(6px)",
+              fontFamily: FONTS.MONO,
+              fontSize: 9.5,
+              letterSpacing: "0.22em",
+              textTransform: "uppercase",
+              color: PALETTE.ASH_DIM,
+              fontWeight: 500,
+            }}
+          >
+            <ShareIcon size={12} color={PALETTE.ASH_DIM} />
+            Share
+          </button>
+        )}
         {!hideNext && (
           <div
             className="ew-card-next"
+            role="button"
+            tabIndex={0}
+            data-cursor="hover"
             onClick={(e) => {
+              e.stopPropagation();
+              onNext?.();
+            }}
+            onKeyDown={(e) => {
+              if (e.key !== "Enter" && e.key !== " ") return;
+              e.preventDefault();
               e.stopPropagation();
               onNext?.();
             }}

--- a/components/ui/CardTypography.tsx
+++ b/components/ui/CardTypography.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import type { CSSProperties, ReactNode } from "react";
-import { motion } from "framer-motion";
-import { PALETTE, FONTS } from "@/constants/colors";
-import type { Accent } from "@/types";
+import type { CSSProperties, ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { PALETTE, FONTS } from '@/constants/colors';
+import type { Accent } from '@/types';
 
 type EarthQuoteProps = {
   children: ReactNode;
@@ -29,20 +29,20 @@ export function EarthQuote({
   right = 32,
 }: EarthQuoteProps) {
   const style: CSSProperties = {
-    position: "absolute",
+    position: 'absolute',
     bottom,
     left,
     right,
     zIndex: 15,
-    textAlign: "center",
+    textAlign: 'center',
     fontFamily: FONTS.SERIF,
     fontSize: 19,
     lineHeight: 1.35,
     color: PALETTE.ASH,
-    fontStyle: "italic",
+    fontStyle: 'italic',
     fontWeight: 400,
-    letterSpacing: "-0.01em",
-    textWrap: "balance",
+    letterSpacing: '-0.01em',
+    textWrap: 'balance',
   };
   return (
     <motion.div
@@ -53,14 +53,14 @@ export function EarthQuote({
     >
       <span
         style={{
-          display: "block",
+          display: 'block',
           fontFamily: FONTS.MONO,
-          fontStyle: "normal",
+          fontStyle: 'normal',
           fontSize: 9,
-          letterSpacing: "0.3em",
+          letterSpacing: '0.3em',
           color: PALETTE.ASH_DIMMER,
           marginBottom: 14,
-          textTransform: "uppercase",
+          textTransform: 'uppercase',
           fontWeight: 500,
         }}
       >
@@ -75,16 +75,16 @@ export function StatLabel({ children, bottom = 180 }: StatLabelProps) {
   return (
     <div
       style={{
-        position: "absolute",
+        position: 'absolute',
         bottom,
         left: 0,
         right: 0,
         zIndex: 15,
-        textAlign: "center",
+        textAlign: 'center',
         fontFamily: FONTS.MONO,
         fontSize: 12.5,
-        letterSpacing: "0.24em",
-        textTransform: "uppercase",
+        letterSpacing: '0.24em',
+        textTransform: 'uppercase',
         color: PALETTE.ASH,
         fontWeight: 500,
       }}
@@ -98,10 +98,10 @@ export function HorizonLine({ accent, bottom = 158 }: HorizonLineProps) {
   return (
     <div
       style={{
-        position: "absolute",
+        position: 'absolute',
         bottom,
-        left: 40,
-        right: 40,
+        left: 25,
+        right: 25,
         zIndex: 15,
         height: 1,
         background: `linear-gradient(90deg, transparent, ${PALETTE.ASH_DIMMER}, ${accent.hex}, ${PALETTE.ASH_DIMMER}, transparent)`,


### PR DESCRIPTION
## Summary

Update the share poster composition and wire it to the current user's pledge.

## What changed

- restored the side-by-side quote/stats poster composition
- staggered the layout vertically:
  - pledge quote sits higher on the left
  - stats sit lower on the right
- kept the globe as the background anchor
- kept the footer with `thisyear.earth` and the live pledge count
- passed the current `userPledge` into the share sheet from:
  - `MobileStory.tsx`
  - `DesktopStory.tsx`

## Why

This makes the share asset feel more personal and more aligned with the
Earth Wrapped identity:
- the exported poster now reflects the user's actual pledge
- the staggered composition gives the quote and the ledger clearer visual roles
- the globe/footer structure remains intact as the planetary record layer

## Validation

- `npm run lint` passes
- `npm run build` passes