### PR TITLE
feat(db): wire Neon-backed pledges and locations to the live schema

### DIFF
--- a/.agents/skills/neon-postgres/SKILL.md
+++ b/.agents/skills/neon-postgres/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: neon-postgres
+description: Guides and best practices for working with Neon Serverless Postgres. Covers getting started, local development with Neon, choosing a connection method, Neon features, authentication (@neondatabase/auth), PostgREST-style data API (@neondatabase/neon-js), Neon CLI, and Neon's Platform API/SDKs. Use for any Neon-related questions.
+---
+
+# Neon Serverless Postgres
+
+Neon is a serverless Postgres platform that separates compute and storage to offer autoscaling, branching, instant restore, and scale-to-zero. It's fully compatible with Postgres and works with any language, framework, or ORM that supports Postgres.
+
+## Neon Documentation
+
+The Neon documentation is the source of truth for all Neon-related information. Always verify claims against the official docs before responding. Neon features and APIs evolve, so prefer fetching current docs over relying on training data.
+
+### Fetching Docs as Markdown
+
+Any Neon doc page can be fetched as markdown in two ways:
+
+1. **Append `.md` to the URL** (simplest): https://neon.com/docs/introduction/branching.md
+2. **Request `text/markdown`** on the standard URL: `curl -H "Accept: text/markdown" https://neon.com/docs/introduction/branching`
+
+Both return the same markdown content. Use whichever method your tools support.
+
+### Finding the Right Page
+
+The docs index lists every available page with its URL and a short description:
+
+```
+https://neon.com/docs/llms.txt
+```
+
+Common doc URLs are organized in the topic links below. If you need a page not listed here, search the docs index: https://neon.com/docs/llms.txt — don't guess URLs.
+
+## What Is Neon
+
+Use this for architecture explanations and terminology (organizations, projects, branches, endpoints) before giving implementation advice.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/what-is-neon.md
+
+## Getting Started
+
+Use this for first-time setup: org/project selection, connection strings, driver installation, optional auth, and initial schema setup.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md
+
+## Connection Methods & Drivers
+
+Use this when you need to pick the correct transport and driver based on runtime constraints (TCP, HTTP, WebSocket, edge, serverless, long-running).
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md
+
+### Serverless Driver
+
+Use this for `@neondatabase/serverless` patterns, including HTTP queries, WebSocket transactions, and runtime-specific optimizations.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md
+
+### Neon JS SDK
+
+Use this for combined Neon Auth + Data API workflows with PostgREST-style querying and typed client setup.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md
+
+## Developer Tools
+
+Use this for local development enablement with `npx neonctl@latest init`, VSCode extension setup, and Neon MCP server configuration.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md
+
+### Neon CLI
+
+Use this for terminal-first workflows, scripts, and CI/CD automation with `neonctl`.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md
+
+## Neon Admin API
+
+The Neon Admin API can be used to manage Neon resources programmatically. It is used behind the scenes by the Neon CLI and MCP server, but can also be used directly for more complex automation workflows or when embedding Neon in other applications.
+
+### Neon REST API
+
+Use this for direct HTTP automation, endpoint-level control, API key auth, rate-limit handling, and operation polling.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-rest-api.md
+
+### Neon TypeScript SDK
+
+Use this when implementing typed programmatic control of Neon resources in TypeScript via `@neondatabase/api-client`.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-typescript-sdk.md
+
+### Neon Python SDK
+
+Use this when implementing programmatic Neon management in Python with the `neon-api` package.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-python-sdk.md
+
+## Neon Auth
+
+Use this for managed user authentication setup, UI components, auth methods, and Neon Auth integration pitfalls in Next.js and React apps.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md
+
+Neon Auth is also embedded in the Neon JS SDK - so depending on your use case, you may want to use the Neon JS SDK instead of Neon Auth. See https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md for more details.
+
+## Branching
+
+Use this when the user is planning isolated environments, schema migration testing, preview deployments, or branch lifecycle automation.
+
+Key points:
+
+- Branches are instant, copy-on-write clones (no full data copy).
+- Each branch has its own compute endpoint.
+- Use the neonctl CLI or MCP server to create, inspect, and compare branches.
+
+Link: https://neon.com/docs/ai/skills/neon-postgres/references/branching.md
+
+## Autoscaling
+
+Use this when the user needs compute to scale automatically with workload and wants guidance on CU sizing and runtime behavior.
+
+Link: https://neon.com/docs/introduction/autoscaling.md
+
+## Scale to Zero
+
+Use this when optimizing idle costs and discussing suspend/resume behavior, including cold-start trade-offs.
+
+Key points:
+
+- Idle computes suspend automatically (default 5 minutes, configurable) (unless disabled - launch & scale plan only)
+- First query after suspend typically has a cold-start penalty (around hundreds of ms)
+- Storage remains active while compute is suspended.
+
+Link: https://neon.com/docs/introduction/scale-to-zero.md
+
+## Instant Restore
+
+Use this when the user needs point-in-time recovery or wants to restore data state without traditional backup restore workflows.
+
+Key points:
+
+- Restore windows depend on plan limits.
+- Users can create branches from historical points-in-time.
+- Time Travel queries can be used for historical inspection workflows.
+
+Link: https://neon.com/docs/introduction/branch-restore.md
+
+## Read Replicas
+
+Use this for read-heavy workloads where the user needs dedicated read-only compute without duplicating storage.
+
+Key points:
+
+- Replicas are read-only compute endpoints sharing the same storage.
+- Creation is fast and scaling is independent from primary compute.
+- Typical use cases: analytics, reporting, and read-heavy APIs.
+
+Link: https://neon.com/docs/introduction/read-replicas.md
+
+## Connection Pooling
+
+Use this when the user is in serverless or high-concurrency environments and needs safe, scalable Postgres connection management.
+
+Key points:
+
+- Neon pooling uses PgBouncer.
+- Add `-pooler` to endpoint hostnames to use pooled connections.
+- Pooling is especially important in serverless runtimes with bursty concurrency.
+
+Link: https://neon.com/docs/connect/connection-pooling.md
+
+## IP Allow Lists
+
+Use this when the user needs to restrict database access by trusted networks, IPs, or CIDR ranges.
+
+Link: https://neon.com/docs/introduction/ip-allow.md
+
+## Logical Replication
+
+Use this when integrating CDC pipelines, external Postgres sync, or replication-based data movement.
+
+Key points:
+
+- Neon supports native logical replication workflows.
+- Useful for replicating to/from external Postgres systems.
+
+Link: https://neon.com/docs/guides/logical-replication-guide.md

--- a/app/api/locations/route.ts
+++ b/app/api/locations/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { recentLocations, recordLocation } from "@/lib/db/locations";
+
+function optionalCoordinate(value: unknown, min: number, max: number): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n) || n < min || n > max) return null;
+  return n;
+}
+
+export async function GET() {
+  const locations = await recentLocations(50);
+  return NextResponse.json({ locations });
+}
+
+export async function POST(req: NextRequest) {
+  let body: {
+    country?: unknown;
+    country_code?: unknown;
+    countryCode?: unknown;
+    lat?: unknown;
+    lng?: unknown;
+    lon?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+
+  const country = typeof body.country === "string" ? body.country.trim() : "";
+  const countryCodeSource =
+    typeof body.country_code === "string" ? body.country_code : body.countryCode;
+  const countryCode =
+    typeof countryCodeSource === "string"
+      ? countryCodeSource.trim().toUpperCase()
+      : "";
+
+  if (!country) {
+    return NextResponse.json({ error: "country required" }, { status: 400 });
+  }
+
+  if (countryCode.length !== 2) {
+    return NextResponse.json({ error: "country_code must be 2 characters" }, { status: 400 });
+  }
+
+  const lat = optionalCoordinate(body.lat, -90, 90);
+  const lng = optionalCoordinate(body.lng ?? body.lon, -180, 180);
+  await recordLocation({
+    country,
+    countryCode,
+    lat,
+    lng,
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/pledges/route.ts
+++ b/app/api/pledges/route.ts
@@ -10,28 +10,54 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  let body: { text?: unknown };
+  let body: {
+    pledge_text?: unknown;
+    text?: unknown;
+    name?: unknown;
+    country?: unknown;
+    country_code?: unknown;
+    countryCode?: unknown;
+  };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "invalid json" }, { status: 400 });
   }
-  const text =
-    typeof body.text === "string" ? body.text.trim().slice(0, 200) : "";
-  if (text.length < 3) {
+  const pledgeTextSource =
+    typeof body.pledge_text === "string" ? body.pledge_text : body.text;
+  const pledgeText =
+    typeof pledgeTextSource === "string" ? pledgeTextSource.trim().slice(0, 200) : "";
+  if (pledgeText.length < 3) {
     return NextResponse.json({ error: "pledge too short" }, { status: 400 });
   }
 
-  const result = await mintPledge(text);
+  const name = typeof body.name === "string" ? body.name.trim().slice(0, 80) : null;
+  const country =
+    typeof body.country === "string" ? body.country.trim().slice(0, 80) : null;
+  const countryCodeSource =
+    typeof body.country_code === "string" ? body.country_code : body.countryCode;
+  const normalizedCountryCode =
+    typeof countryCodeSource === "string"
+      ? countryCodeSource.trim().toUpperCase()
+      : "";
+  const countryCode = normalizedCountryCode.length === 2 ? normalizedCountryCode : null;
+
+  const result = await mintPledge(pledgeText);
   try {
-    await insertPledge(text, result.txHash);
-  } catch {
-    // fall through — still return the receipt
+    await insertPledge({
+      pledgeText,
+      name: name || null,
+      country: country || null,
+      countryCode: countryCode || null,
+    });
+  } catch (error) {
+    console.error("Failed to insert pledge", error);
+    return NextResponse.json({ error: "pledge storage failed" }, { status: 500 });
   }
 
   const pledge: Pledge = {
     choice: null,
-    custom: text,
+    custom: pledgeText,
     minted: true,
     ts: Date.now(),
     txHash: result.txHash,

--- a/components/cards/LocationCard.tsx
+++ b/components/cards/LocationCard.tsx
@@ -47,6 +47,8 @@ export function LocationCard({
     const loc: Location = {
       city: region,
       region,
+      country: region,
+      countryCode: "ZZ",
       lat: 0,
       lon: 0,
       tz: "UTC",

--- a/constants/endpoints.ts
+++ b/constants/endpoints.ts
@@ -1,5 +1,6 @@
 export const ENDPOINTS = {
   CO2: "/api/co2",
+  LOCATIONS: "/api/locations",
   PLEDGES: "/api/pledges",
   NOAA_CO2_CSV:
     "https://gml.noaa.gov/webdata/ccgg/trends/co2/co2_daily_mlo.csv",

--- a/hooks/useLocation.ts
+++ b/hooks/useLocation.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { ENDPOINTS } from "@/constants/endpoints";
 import type { Location } from "@/types";
 
 type LocationState = {
@@ -10,11 +11,60 @@ type LocationState = {
 };
 
 const FAKE_LOCATIONS: Location[] = [
-  { city: "San Francisco", region: "North America", lat: 37.77, lon: -122.42, tz: "UTC-08" },
-  { city: "Berlin", region: "Europe", lat: 52.52, lon: 13.4, tz: "UTC+01" },
-  { city: "Lagos", region: "Africa", lat: 6.52, lon: 3.37, tz: "UTC+01" },
-  { city: "Tokyo", region: "Asia", lat: 35.68, lon: 139.69, tz: "UTC+09" },
+  {
+    city: "San Francisco",
+    region: "North America",
+    country: "United States",
+    countryCode: "US",
+    lat: 37.77,
+    lon: -122.42,
+    tz: "UTC-08",
+  },
+  {
+    city: "Berlin",
+    region: "Europe",
+    country: "Germany",
+    countryCode: "DE",
+    lat: 52.52,
+    lon: 13.4,
+    tz: "UTC+01",
+  },
+  {
+    city: "Lagos",
+    region: "Africa",
+    country: "Nigeria",
+    countryCode: "NG",
+    lat: 6.52,
+    lon: 3.37,
+    tz: "UTC+01",
+  },
+  {
+    city: "Tokyo",
+    region: "Asia",
+    country: "Japan",
+    countryCode: "JP",
+    lat: 35.68,
+    lon: 139.69,
+    tz: "UTC+09",
+  },
 ];
+
+async function persistLocation(loc: Location) {
+  try {
+    await fetch(ENDPOINTS.LOCATIONS, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        country: loc.country,
+        country_code: loc.countryCode,
+        lat: loc.lat,
+        lng: loc.lon,
+      }),
+    });
+  } catch {
+    // Location storage should not block the story.
+  }
+}
 
 export function useLocation(initial: Location | null = null) {
   const [state, setState] = useState<LocationState>({
@@ -28,11 +78,13 @@ export function useLocation(initial: Location | null = null) {
     await new Promise((r) => setTimeout(r, 1200));
     const pick = FAKE_LOCATIONS[Math.floor(Math.random() * FAKE_LOCATIONS.length)];
     setState({ loading: false, error: null, location: pick });
+    void persistLocation(pick);
     return pick;
   }, []);
 
   const setManual = useCallback((loc: Location) => {
     setState({ loading: false, error: null, location: loc });
+    void persistLocation(loc);
   }, []);
 
   return { ...state, detect, setManual };

--- a/hooks/usePledge.ts
+++ b/hooks/usePledge.ts
@@ -45,7 +45,7 @@ export function useMintPledge() {
         const res = await fetch(ENDPOINTS.PLEDGES, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ text }),
+          body: JSON.stringify({ pledge_text: text }),
         });
         if (!res.ok) throw new Error(`mint failed: ${res.status}`);
         const data = (await res.json()) as { pledge: Pledge };

--- a/lib/db/locations.ts
+++ b/lib/db/locations.ts
@@ -1,28 +1,68 @@
 import { getSql } from "./client";
-import type { Location } from "@/types";
 
-let memoryStore: Location[] = [];
+export type LocationRow = {
+  id: string;
+  country: string;
+  countryCode: string;
+  lat: number | null;
+  lng: number | null;
+  createdAt: Date | string;
+};
 
-export async function recordLocation(loc: Location): Promise<void> {
+type RecordLocationInput = {
+  country: string;
+  countryCode: string;
+  lat?: number | null;
+  lng?: number | null;
+};
+
+let memoryStore: LocationRow[] = [];
+
+export async function recordLocation(loc: RecordLocationInput): Promise<void> {
   const sql = getSql();
   if (!sql) {
-    memoryStore = [loc, ...memoryStore].slice(0, 1000);
+    memoryStore = [
+      {
+        id: crypto.randomUUID(),
+        country: loc.country,
+        countryCode: loc.countryCode,
+        lat: loc.lat ?? null,
+        lng: loc.lng ?? null,
+        createdAt: new Date().toISOString(),
+      },
+      ...memoryStore,
+    ].slice(0, 1000);
     return;
   }
   await sql`
-    INSERT INTO locations (city, region, lat, lon, tz, created_at)
-    VALUES (${loc.city}, ${loc.region}, ${loc.lat}, ${loc.lon}, ${loc.tz}, NOW())
+    INSERT INTO locations (country, country_code, lat, lng)
+    VALUES (${loc.country}, ${loc.countryCode}, ${loc.lat ?? null}, ${loc.lng ?? null})
   `;
 }
 
-export async function recentLocations(limit = 20): Promise<Location[]> {
+export async function recentLocations(limit = 20): Promise<LocationRow[]> {
   const sql = getSql();
   if (!sql) return memoryStore.slice(0, limit);
   const rows = (await sql`
-    SELECT city, region, lat, lon, tz
+    SELECT id, country, country_code, lat, lng, created_at
     FROM locations
     ORDER BY created_at DESC
     LIMIT ${limit}
-  `) as Location[];
-  return rows;
+  `) as {
+    id: string;
+    country: string;
+    country_code: string;
+    lat: string | number | null;
+    lng: string | number | null;
+    created_at: Date | string;
+  }[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    country: row.country,
+    countryCode: row.country_code,
+    lat: row.lat === null ? null : Number(row.lat),
+    lng: row.lng === null ? null : Number(row.lng),
+    createdAt: row.created_at,
+  }));
 }

--- a/lib/db/pledges.ts
+++ b/lib/db/pledges.ts
@@ -2,21 +2,29 @@ import { getSql } from "./client";
 
 export type PledgeRow = {
   id: string;
-  text: string;
-  txHash: string;
-  createdAt: string;
+  pledgeText: string;
+  name: string | null;
+  country: string | null;
+  countryCode: string | null;
+  createdAt: Date | string;
 };
 
 let memoryStore: PledgeRow[] = [];
 
-export async function insertPledge(
-  text: string,
-  txHash: string,
-): Promise<PledgeRow> {
+type InsertPledgeInput = {
+  pledgeText: string;
+  name?: string | null;
+  country?: string | null;
+  countryCode?: string | null;
+};
+
+export async function insertPledge(input: InsertPledgeInput): Promise<PledgeRow> {
   const row: PledgeRow = {
     id: crypto.randomUUID(),
-    text,
-    txHash,
+    pledgeText: input.pledgeText,
+    name: input.name ?? null,
+    country: input.country ?? null,
+    countryCode: input.countryCode ?? null,
     createdAt: new Date().toISOString(),
   };
 
@@ -26,11 +34,29 @@ export async function insertPledge(
     return row;
   }
 
-  await sql`
-    INSERT INTO pledges (id, text, tx_hash, created_at)
-    VALUES (${row.id}, ${row.text}, ${row.txHash}, ${row.createdAt})
-  `;
-  return row;
+  const rows = (await sql`
+    INSERT INTO pledges (pledge_text, name, country, country_code)
+    VALUES (${row.pledgeText}, ${row.name}, ${row.country}, ${row.countryCode})
+    RETURNING id, pledge_text, name, country, country_code, created_at
+  `) as {
+    id: string;
+    pledge_text: string;
+    name: string | null;
+    country: string | null;
+    country_code: string | null;
+    created_at: Date | string;
+  }[];
+
+  const saved = rows[0];
+  if (!saved) return row;
+  return {
+    id: saved.id,
+    pledgeText: saved.pledge_text,
+    name: saved.name,
+    country: saved.country,
+    countryCode: saved.country_code,
+    createdAt: saved.created_at,
+  };
 }
 
 export async function countPledges(): Promise<number> {

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "391693eee67001639ab65474df185da3ea5cf9ee4b99badecfd64561113edbb4"
+    }
+  }
+}

--- a/types/location.ts
+++ b/types/location.ts
@@ -1,6 +1,8 @@
 export type Location = {
   city: string;
   region: string;
+  country: string;
+  countryCode: string;
   lat: number;
   lon: number;
   tz: string;


### PR DESCRIPTION
## Summary

Wire the app to the live Neon schema for both pledges and locations.

## What changed

### Pledges
- updated `lib/db/pledges.ts` to insert into the real `pledges` table shape:
  `pledge_text`, `name`, `country`, `country_code`
- removed outdated assumptions about old columns like `text` and `tx_hash`
- updated `app/api/pledges/route.ts` to:
  - accept `pledge_text`
  - validate required input
  - normalize optional `country_code`
  - return `500` on storage failure instead of pretending the write succeeded
- updated `hooks/usePledge.ts` to post `{ pledge_text: text }`

### Locations
- updated `lib/db/locations.ts` to read/write the real `locations` table shape:
  `country`, `country_code`, `lat`, `lng`, `created_at`
- added `app/api/locations/route.ts` with minimal `GET` and `POST` handlers
- added the `LOCATIONS` endpoint constant
- updated `hooks/useLocation.ts` to persist detected/manual locations through
  `/api/locations`
- added the minimum `country` / `countryCode` fields needed in location types/UI
  while preserving the current UX


## Validation

- `npm run lint` passes
- `npm run build` passes
- build output now includes:
  - `/api/pledges`
  - `/api/locations`
