### PR TITLE
feat(share): finalize export-safe share poster and wire share actions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,16 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
+.ew-share-sheet-panel {
+  scrollbar-width: none;
+}
+
+.ew-share-sheet-panel::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 /* ───────────────────────────────────────────────────────────── */
 /* Mobile + Tablet (≤ 1023px) — full-viewport card, no frame    */
 /* ───────────────────────────────────────────────────────────── */

--- a/components/cards/CO2Card.tsx
+++ b/components/cards/CO2Card.tsx
@@ -124,7 +124,7 @@ export function CO2Card({
 
       <StatLabel>Above preindustrial</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
       <StatSourceMeta
         rows={['SRC: NOAA GML']}
         dim={['MAUNA LOA', 'PRELIMINARY']}

--- a/components/cards/ForestCard.tsx
+++ b/components/cards/ForestCard.tsx
@@ -7,11 +7,13 @@ import { StatBlock, StatLadder, StatSourceMeta } from "./StatBlock";
 import { EarthQuote, StatLabel, HorizonLine } from "@/components/ui/CardTypography";
 import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
 import { useEarthVoice } from "@/hooks/useEarthVoice";
+import { useMediaMin } from "@/hooks/useBreakpoint";
 
 const accent = ACCENTS.forest;
 
 export function ForestCard({ active, onNext, onShare, grainLevel, voiceTone }: CardCommonProps) {
   const quote = useEarthVoice("forest", voiceTone);
+  const isDesktop = useMediaMin(1024);
 
   return (
     <CardShell
@@ -79,7 +81,7 @@ export function ForestCard({ active, onNext, onShare, grainLevel, voiceTone }: C
 
       <StatLabel>Forest I lost this year</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/cards/IceCard.tsx
+++ b/components/cards/IceCard.tsx
@@ -38,7 +38,7 @@ export function IceCard({ active, onNext, onShare, grainLevel, voiceTone }: Card
       <svg
         style={{
           position: "absolute",
-          bottom: isDesktop ? 168 : 205,
+          bottom: isDesktop ? 190 : 205,
           left: 0,
           right: 0,
           width: "100%",
@@ -74,9 +74,9 @@ export function IceCard({ active, onNext, onShare, grainLevel, voiceTone }: Card
         dim={["CRYOSPHERE", "ANNUAL NET"]}
       />
 
-      <StatLabel bottom={isDesktop ? 128 : undefined}>Ice lost from my shoulders</StatLabel>
-      <HorizonLine accent={accent} bottom={isDesktop ? 104 : undefined} />
-      <EarthQuote bottom={isDesktop ? 42 : undefined}>&ldquo;{quote}&rdquo;</EarthQuote>
+      <StatLabel bottom={isDesktop ? 148 : undefined}>Ice lost from my shoulders</StatLabel>
+      <HorizonLine accent={accent} bottom={isDesktop ? 124 : undefined} />
+      <EarthQuote bottom={isDesktop ? 62 : undefined}>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/cards/RenewablesCard.tsx
+++ b/components/cards/RenewablesCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/CardTypography';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { useEarthVoice } from '@/hooks/useEarthVoice';
+import { useMediaMin } from '@/hooks/useBreakpoint';
 
 const accent = ACCENTS.renewables;
 
@@ -22,6 +23,7 @@ export function RenewablesCard({
   voiceTone,
 }: CardCommonProps) {
   const quote = useEarthVoice('renewables', voiceTone);
+  const isDesktop = useMediaMin(1024);
 
   return (
     <CardShell
@@ -69,7 +71,7 @@ export function RenewablesCard({
       <svg
         style={{
           position: 'absolute',
-          bottom: 195,
+          bottom: isDesktop ? 195 : 212,
           left: 40,
           right: 40,
           height: 44,

--- a/components/cards/SpeciesCard.tsx
+++ b/components/cards/SpeciesCard.tsx
@@ -7,11 +7,13 @@ import { StatBlock, StatLadder, StatSourceMeta } from "./StatBlock";
 import { EarthQuote, StatLabel, HorizonLine } from "@/components/ui/CardTypography";
 import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
 import { useEarthVoice } from "@/hooks/useEarthVoice";
+import { useMediaMin } from "@/hooks/useBreakpoint";
 
 const accent = ACCENTS.species;
 
 export function SpeciesCard({ active, onNext, onShare, grainLevel, voiceTone }: CardCommonProps) {
   const quote = useEarthVoice("species", voiceTone);
+  const isDesktop = useMediaMin(1024);
 
   return (
     <CardShell
@@ -78,7 +80,7 @@ export function SpeciesCard({ active, onNext, onShare, grainLevel, voiceTone }: 
 
       <StatLabel>Species on my list</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/ui/ShareSheet.tsx
+++ b/components/ui/ShareSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { PALETTE, FONTS, ACCENTS } from "@/constants/colors";
 import type { CardId, Pledge } from "@/types";
@@ -35,6 +35,51 @@ const PRESET_PLEDGE_LINES: Record<string, string[]> = {
   repair: ["I will repair more", "this year. Every", "thing kept counts."],
 };
 
+const SHARE_COUNT_THRESHOLD = 100;
+const SHARE_URL = `https://${SITE.domain}`;
+const SHARE_TEXT = "I made a pledge to Earth.";
+const POSTER_WIDTH = 1080;
+const POSTER_HEIGHT = 1920;
+const POSTER_FILENAME = "earth-wrapped-pledge.png";
+
+type ShareActionKind = "story" | "x" | "copy-image" | "copy-link";
+
+const QUOTE_LAYOUTS = {
+  hero: {
+    previewFontSize: "clamp(17px, 4.8vw, 23px)",
+    previewLineHeight: 1.22,
+    previewWidthDesktop: "65%",
+    previewWidthMobile: "70%",
+    posterFontSize: 62,
+    posterLineHeight: 74,
+    posterSignatureFontSize: 44,
+    signatureGap: 24,
+    posterSignatureGap: 58,
+  },
+  medium: {
+    previewFontSize: "clamp(16px, 4.45vw, 21.5px)",
+    previewLineHeight: 1.17,
+    previewWidthDesktop: "68%",
+    previewWidthMobile: "73%",
+    posterFontSize: 58,
+    posterLineHeight: 68,
+    posterSignatureFontSize: 41,
+    signatureGap: 18,
+    posterSignatureGap: 48,
+  },
+  compact: {
+    previewFontSize: "clamp(15.5px, 4.2vw, 20.5px)",
+    previewLineHeight: 1.14,
+    previewWidthDesktop: "72%",
+    previewWidthMobile: "76%",
+    posterFontSize: 53,
+    posterLineHeight: 62,
+    posterSignatureFontSize: 38,
+    signatureGap: 14,
+    posterSignatureGap: 36,
+  },
+} as const;
+
 export function ShareSheet({ open, cardId, pledge, onClose }: ShareSheetProps) {
   return (
     <AnimatePresence>
@@ -53,10 +98,92 @@ function Sheet({
   onClose: () => void;
 }) {
   void cardId;
-  const [copied, setCopied] = useState(false);
+  const posterRef = useRef<HTMLCanvasElement>(null);
+  const [busyAction, setBusyAction] = useState<ShareActionKind | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
   const pledgeCount = usePledgeCount(3000);
   const pledgeLines = getPledgeLines(pledge);
+  const signatureName = getSignatureName(pledge);
+  const quoteLength = getPledgeCharacterLength(pledge, pledgeLines);
+  const quoteLayout = getQuoteLayout(quoteLength);
   const isDesktop = useMediaMin(1024);
+  const footerPledgeText =
+    pledgeCount >= SHARE_COUNT_THRESHOLD
+      ? `Pledges minted · live · ${pledgeCount.toLocaleString("en-US")}`
+      : "Pledges minted · live";
+
+  const runAction = async (
+    action: ShareActionKind,
+    handler: () => Promise<string> | string,
+  ) => {
+    if (busyAction) return;
+    setBusyAction(action);
+    setActionMessage(null);
+    try {
+      const message = await handler();
+      setActionMessage(message);
+      window.setTimeout(() => setActionMessage(null), 1800);
+    } catch {
+      setActionMessage("Something went wrong. Try again.");
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const createPosterBlob = async () => {
+    if (!posterRef.current) {
+      throw new Error("Share poster is not mounted.");
+    }
+    return renderPosterCanvasToPngBlob(posterRef.current);
+  };
+
+  const handleStoryShare = () =>
+    runAction("story", async () => {
+      const blob = await createPosterBlob();
+      if (isDesktop) {
+        downloadBlob(blob, POSTER_FILENAME);
+        return "Image downloaded.";
+      }
+
+      const file = new File([blob], POSTER_FILENAME, { type: "image/png" });
+      if (navigator.canShare?.({ files: [file] })) {
+        await navigator.share({
+          files: [file],
+          title: SITE.name,
+          text: SHARE_TEXT,
+          url: SHARE_URL,
+        });
+        return "Opened share sheet.";
+      }
+      downloadBlob(blob, POSTER_FILENAME);
+      return "Image downloaded.";
+    });
+
+  const handleXPost = () =>
+    runAction("x", () => {
+      const intentUrl = new URL("https://x.com/compose/post");
+      intentUrl.searchParams.set("text", `${SHARE_TEXT} ${SHARE_URL}`);
+      const opened = window.open(intentUrl.toString(), "_blank", "noopener,noreferrer");
+      if (!opened) window.location.href = intentUrl.toString();
+      return "Opening X.";
+    });
+
+  const handleCopyImage = () =>
+    runAction("copy-image", async () => {
+      const blob = await createPosterBlob();
+      if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+        await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+        return "Image copied.";
+      }
+      downloadBlob(blob, POSTER_FILENAME);
+      return "Image downloaded.";
+    });
+
+  const handleCopyLink = () =>
+    runAction("copy-link", async () => {
+      await copyTextToClipboard(SHARE_URL);
+      return "Link copied.";
+    });
 
   return (
     <motion.div
@@ -76,9 +203,11 @@ function Sheet({
         alignItems: isDesktop ? "center" : "flex-end",
         justifyContent: isDesktop ? "center" : undefined,
         padding: isDesktop ? 24 : 0,
+        overflow: "hidden",
       }}
     >
       <motion.div
+        className="ew-share-sheet-panel"
         onClick={(e) => e.stopPropagation()}
         variants={sheetSlideUp}
         initial="hidden"
@@ -87,8 +216,9 @@ function Sheet({
         transition={{ duration: 0.4, ease: EASE_OUT }}
         style={{
           width: isDesktop ? "min(460px, calc(100vw - 48px))" : "100%",
-          maxHeight: isDesktop ? "calc(100dvh - 48px)" : undefined,
-          overflowY: isDesktop ? "auto" : undefined,
+          maxHeight: isDesktop ? "calc(100dvh - 48px)" : "100dvh",
+          overflowY: isDesktop ? "auto" : "hidden",
+          overscrollBehavior: "contain",
           borderRadius: isDesktop ? 18 : "24px 24px 0 0",
           background: "linear-gradient(180deg, #0e1220 0%, #070a12 100%)",
           border: "1px solid rgba(230,214,190,0.12)",
@@ -122,8 +252,10 @@ function Sheet({
         <div
           style={{
             width: "100%",
-            maxWidth: isDesktop ? 420 : undefined,
-            margin: isDesktop ? "0 auto 14px" : "0 0 16px",
+            maxWidth: isDesktop
+              ? 420
+              : "min(100%, 360px, calc((100dvh - 300px) * 9 / 14))",
+            margin: isDesktop ? "0 auto 14px" : "0 auto 16px",
             aspectRatio: "9 / 14",
             borderRadius: 14,
             overflow: "hidden",
@@ -168,48 +300,58 @@ function Sheet({
           <div
             style={{
               position: "absolute",
-              top: isDesktop ? "23%" : "20%",
+              top: isDesktop ? "18%" : "17%",
               left: 26,
-              width: "46%",
+              width: isDesktop
+                ? quoteLayout.previewWidthDesktop
+                : quoteLayout.previewWidthMobile,
               zIndex: 5,
             }}
           >
             <div
               style={{
                 fontFamily: FONTS.SERIF,
-                fontSize: "clamp(18px, 5vw, 24px)",
-                lineHeight: 1.22,
+                fontSize: quoteLayout.previewFontSize,
+                lineHeight: quoteLayout.previewLineHeight,
                 fontStyle: "italic",
                 color: PALETTE.ASH,
                 letterSpacing: "-0.01em",
                 textWrap: "balance",
+                overflowWrap: "anywhere",
               }}
             >
               &ldquo;
               {pledgeLines.map((line, index) => (
-                <span key={line}>
+                <span key={`${line}-${index}`}>
                   {line}
                   {index < pledgeLines.length - 1 && <br />}
                 </span>
               ))}
               &rdquo;
-              <div
-                style={{
-                  marginTop: 30,
-                  fontSize: "0.78em",
-                  textAlign: "center",
-                  color: PALETTE.ASH_DIM,
-                }}
-              >
-                — Sara
-              </div>
+              {signatureName && (
+                <div
+                  title={signatureName}
+                  style={{
+                    marginTop: quoteLayout.signatureGap,
+                    fontSize: "0.74em",
+                    textAlign: "center",
+                    color: PALETTE.ASH_DIM,
+                    maxWidth: "84%",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  — {signatureName}
+                </div>
+              )}
             </div>
           </div>
 
           <div
             style={{
               position: "absolute",
-              top: isDesktop ? "49%" : "56%",
+              top: isDesktop ? "59%" : "66%",
               right: 24,
               width: "42%",
               zIndex: 5,
@@ -228,8 +370,8 @@ function Sheet({
             >
               {SHARE_STATS.map(([name, value]) => (
                 <div key={name}>
-                  <span style={{ color: PALETTE.ASH_DIM }}>{name}</span>
-                  <span style={{ color: PALETTE.ASH_DIMMER }}> · </span>
+                  <span style={{ color: "rgba(230,214,190,0.62)" }}>{name}</span>
+                  <span style={{ color: "rgba(230,214,190,0.38)" }}> · </span>
                   <span>{value}</span>
                 </div>
               ))}
@@ -241,7 +383,7 @@ function Sheet({
               position: "absolute",
               left: 20,
               right: 20,
-              bottom: 48,
+              bottom: 51,
               zIndex: 5,
               height: 1,
               background:
@@ -252,7 +394,7 @@ function Sheet({
           <div
             style={{
               position: "absolute",
-              bottom: 19,
+              bottom: 21,
               left: 0,
               right: 0,
               zIndex: 5,
@@ -266,27 +408,51 @@ function Sheet({
             }}
           >
             <div>{SITE.domain}</div>
-            <div>Pledges minted · live · {pledgeCount.toLocaleString("en-US")}</div>
+            <div>{footerPledgeText}</div>
           </div>
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-          <ShareAction label="Instagram" sub="Stories" onClick={() => {}} />
-          <ShareAction label="X" sub="Post" onClick={() => {}} />
-          <ShareAction label="Copy Image" sub="PNG · 1080×1920" onClick={() => {}} />
           <ShareAction
-            label={copied ? "Copied ✓" : "Copy Link"}
-            sub={SITE.domain}
-            onClick={() => {
-              if (typeof window !== "undefined") {
-                window.navigator.clipboard
-                  ?.writeText(`https://${SITE.domain}`)
-                  .catch(() => {});
-              }
-              setCopied(true);
-              setTimeout(() => setCopied(false), 1500);
-            }}
+            label={busyAction === "story" ? "Working..." : isDesktop ? "Download" : "Share"}
+            sub="Story Image"
+            onClick={handleStoryShare}
+            disabled={!!busyAction}
           />
+          <ShareAction
+            label={busyAction === "x" ? "Opening..." : "X"}
+            sub="Post"
+            onClick={handleXPost}
+            disabled={!!busyAction}
+          />
+          <ShareAction
+            label={busyAction === "copy-image" ? "Copying..." : "Copy Image"}
+            sub="PNG · 1080×1920"
+            onClick={handleCopyImage}
+            disabled={!!busyAction}
+          />
+          <ShareAction
+            label={busyAction === "copy-link" ? "Copying..." : "Copy Link"}
+            sub={SITE.domain}
+            onClick={handleCopyLink}
+            disabled={!!busyAction}
+          />
+        </div>
+
+        <div
+          role="status"
+          style={{
+            minHeight: 18,
+            marginTop: 10,
+            textAlign: "center",
+            fontFamily: FONTS.MONO,
+            fontSize: 8,
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+            color: PALETTE.ASH_DIM,
+          }}
+        >
+          {actionMessage}
         </div>
 
         <button
@@ -306,6 +472,14 @@ function Sheet({
         >
           Close
         </button>
+
+        <SharePoster
+          ref={posterRef}
+          pledgeLines={pledgeLines}
+          signatureName={signatureName}
+          footerPledgeText={footerPledgeText}
+          quoteLayout={quoteLayout}
+        />
       </motion.div>
     </motion.div>
   );
@@ -321,23 +495,66 @@ function getPledgeLines(pledge?: Pledge | null) {
 }
 
 function wrapPledge(text: string) {
+  const maxLineLength = 30;
+  const maxLines = 5;
   const normalized = text.replace(/\s+/g, " ");
   if (normalized.length <= 26) return [normalized, "Every action counts."];
-  const words = normalized.split(" ");
+  const words = normalized
+    .split(" ")
+    .flatMap((word) => splitLongWord(word, maxLineLength));
   const lines: string[] = [];
   let current = "";
   for (const word of words) {
     const next = current ? `${current} ${word}` : word;
-    if (next.length > 24 && current) {
+    if (next.length > maxLineLength && current) {
       lines.push(current);
       current = word;
     } else {
       current = next;
     }
-    if (lines.length === 2) break;
+    if (lines.length === maxLines) break;
   }
-  if (current && lines.length < 3) lines.push(current);
-  return lines.slice(0, 3);
+  if (current && lines.length < maxLines) lines.push(current);
+  if (lines.length === maxLines && words.join(" ").length > lines.join(" ").length) {
+    lines[maxLines - 1] = trimWithEllipsis(lines[maxLines - 1], maxLineLength);
+  }
+  return lines.slice(0, maxLines);
+}
+
+function splitLongWord(word: string, maxLength: number) {
+  if (word.length <= maxLength) return [word];
+  const chunks: string[] = [];
+  for (let i = 0; i < word.length; i += maxLength) {
+    chunks.push(word.slice(i, i + maxLength));
+  }
+  return chunks;
+}
+
+function trimWithEllipsis(text: string, maxLength: number) {
+  if (text.length <= maxLength - 3) return `${text}...`;
+  return `${text.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function getSignatureName(pledge?: Pledge | null) {
+  return pledge?.name?.trim() || null;
+}
+
+function getPledgeCharacterLength(pledge: Pledge | null | undefined, lines: string[]) {
+  if (pledge?.custom?.trim()) return pledge.custom.trim().length;
+  if (pledge?.choice && PRESET_PLEDGE_LINES[pledge.choice]) {
+    return PRESET_PLEDGE_LINES[pledge.choice][0].length;
+  }
+  return lines.join(" ").length;
+}
+
+function getQuoteLayout(length: number) {
+  if (length >= 61) {
+    return QUOTE_LAYOUTS.compact;
+  }
+  if (length >= 45) {
+    return QUOTE_LAYOUTS.medium;
+  }
+  return QUOTE_LAYOUTS.hero;
 }
 
 function ShareGlobe() {
@@ -349,10 +566,10 @@ function ShareGlobe() {
         position: "absolute",
         top: "50%",
         left: "50%",
-        width: "86%",
+        width: "88%",
         transform: "translate(-50%, -50%)",
         zIndex: 3,
-        opacity: 0.2,
+        opacity: 0.24,
         color: PALETTE.ASH,
       }}
     >
@@ -396,22 +613,26 @@ function ShareAction({
   label,
   sub,
   onClick,
+  disabled = false,
 }: {
   label: string;
   sub: string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       style={{
         all: "unset",
-        cursor: "pointer",
+        cursor: disabled ? "wait" : "pointer",
         textAlign: "center",
         padding: "12px 10px",
         borderRadius: 12,
         background: "rgba(230,214,190,0.04)",
         border: "1px solid rgba(230,214,190,0.14)",
+        opacity: disabled ? 0.62 : 1,
       }}
     >
       <div
@@ -440,4 +661,383 @@ function ShareAction({
       </div>
     </button>
   );
+}
+
+type SharePosterProps = {
+  pledgeLines: string[];
+  signatureName: string | null;
+  footerPledgeText: string;
+  quoteLayout: ReturnType<typeof getQuoteLayout>;
+};
+
+const SharePoster = forwardRef<HTMLCanvasElement, SharePosterProps>(function SharePoster(
+  {
+    pledgeLines,
+    signatureName,
+    footerPledgeText,
+    quoteLayout,
+  },
+  ref,
+) {
+  const localRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const draw = async () => {
+      await document.fonts?.ready;
+      await nextFrame();
+      if (cancelled || !localRef.current) return;
+      drawSharePoster(localRef.current, {
+        pledgeLines,
+        signatureName,
+        footerPledgeText,
+        quoteLayout,
+      });
+      localRef.current.dataset.exportReady = "true";
+    };
+
+    if (localRef.current) localRef.current.dataset.exportReady = "false";
+    void draw();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [footerPledgeText, pledgeLines, quoteLayout, signatureName]);
+
+  const setCanvasRef = (node: HTMLCanvasElement | null) => {
+    localRef.current = node;
+    if (typeof ref === "function") {
+      ref(node);
+    } else if (ref) {
+      ref.current = node;
+    }
+  };
+
+  return (
+    <canvas
+      ref={setCanvasRef}
+      aria-hidden="true"
+      data-export-ready="false"
+      width={POSTER_WIDTH}
+      height={POSTER_HEIGHT}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: -12000,
+        width: POSTER_WIDTH,
+        height: POSTER_HEIGHT,
+        pointerEvents: "none",
+      }}
+    />
+  );
+});
+
+async function renderPosterCanvasToPngBlob(canvas: HTMLCanvasElement) {
+  await waitForPosterReady(canvas);
+  return canvasToPngBlob(canvas);
+}
+
+async function waitForPosterReady(canvas: HTMLCanvasElement) {
+  await document.fonts?.ready;
+  for (let i = 0; i < 24; i += 1) {
+    if (canvas.dataset.exportReady === "true") return;
+    await nextFrame();
+  }
+
+  throw new Error("Share poster is not ready.");
+}
+
+function nextFrame() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+function drawSharePoster(canvas: HTMLCanvasElement, props: SharePosterProps) {
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Canvas is not available.");
+
+  context.clearRect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+  drawPosterBackground(context);
+  drawPosterGrain(context);
+  drawPosterGlobe(context);
+  drawPosterHeader(context);
+  drawPosterPledge(
+    context,
+    props.pledgeLines,
+    props.signatureName,
+    props.quoteLayout,
+  );
+  drawPosterStats(context);
+  drawPosterFooter(context, props.footerPledgeText);
+}
+
+function drawPosterBackground(context: CanvasRenderingContext2D) {
+  const base = context.createLinearGradient(0, 0, 0, POSTER_HEIGHT);
+  base.addColorStop(0, "#0A0E1A");
+  base.addColorStop(0.5, "#0D1322");
+  base.addColorStop(1, "#070A12");
+  context.fillStyle = base;
+  context.fillRect(0, 0, POSTER_WIDTH, POSTER_HEIGHT);
+
+  context.save();
+  context.globalCompositeOperation = "screen";
+  drawEllipseGlow(context, 560, 870, 450, 300, "rgba(230,214,190,0.10)");
+  drawEllipseGlow(context, 540, 1880, 720, 360, "rgba(230,214,190,0.22)");
+  context.restore();
+
+  context.strokeStyle = "rgba(230,214,190,0.14)";
+  context.lineWidth = 2;
+  context.strokeRect(1, 1, POSTER_WIDTH - 2, POSTER_HEIGHT - 2);
+}
+
+function drawEllipseGlow(
+  context: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radiusX: number,
+  radiusY: number,
+  color: string,
+) {
+  context.save();
+  context.translate(x, y);
+  context.scale(radiusX / radiusY, 1);
+  const gradient = context.createRadialGradient(0, 0, 0, 0, 0, radiusY);
+  gradient.addColorStop(0, color);
+  gradient.addColorStop(1, "rgba(230,214,190,0)");
+  context.fillStyle = gradient;
+  context.beginPath();
+  context.arc(0, 0, radiusY, 0, Math.PI * 2);
+  context.fill();
+  context.restore();
+}
+
+function drawPosterGrain(context: CanvasRenderingContext2D) {
+  context.save();
+  context.fillStyle = "#E6D6BE";
+  context.globalAlpha = 0.045;
+
+  let seed = 42;
+  for (let i = 0; i < 9500; i += 1) {
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    const x = seed % POSTER_WIDTH;
+    seed = (seed * 1664525 + 1013904223) >>> 0;
+    const y = seed % POSTER_HEIGHT;
+    context.fillRect(x, y, 1, 1);
+  }
+
+  context.restore();
+}
+
+function drawPosterGlobe(context: CanvasRenderingContext2D) {
+  const cx = 540;
+  const cy = 900;
+  const radius = 382;
+
+  context.save();
+  context.globalAlpha = 0.24;
+  context.strokeStyle = "#E6D6BE";
+  context.fillStyle = "rgba(230,214,190,0.03)";
+  context.lineWidth = 2;
+
+  context.beginPath();
+  context.arc(cx, cy, radius, 0, Math.PI * 2);
+  context.fill();
+  context.stroke();
+
+  context.lineWidth = 1.2;
+  [0, 30, 60, 90, 120, 150].forEach((angle) => {
+    const rx = radius * Math.abs(Math.cos((angle * Math.PI) / 180)) || 2;
+    context.beginPath();
+    context.ellipse(cx, cy, rx, radius, 0, 0, Math.PI * 2);
+    context.stroke();
+  });
+
+  [-60, -30, 0, 30, 60].forEach((lat) => {
+    context.beginPath();
+    context.ellipse(
+      cx,
+      cy + (lat * radius) / 90,
+      radius * Math.cos((lat * Math.PI) / 180),
+      18,
+      0,
+      0,
+      Math.PI * 2,
+    );
+    context.stroke();
+  });
+
+  context.restore();
+}
+
+function drawPosterHeader(context: CanvasRenderingContext2D) {
+  context.save();
+  context.fillStyle = "#E6D6BE";
+  context.font = `500 22px ${FONTS.MONO}`;
+  drawLetterSpacedText(context, `Earth Wrapped · ${SITE.edition}`.toUpperCase(), 70, 120, 6);
+
+  const line = context.createLinearGradient(70, 155, 1010, 155);
+  line.addColorStop(0, "rgba(230,214,190,0.15)");
+  line.addColorStop(0.5, "rgba(230,214,190,0.74)");
+  line.addColorStop(1, "rgba(230,214,190,0.15)");
+  context.strokeStyle = line;
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(70, 155);
+  context.lineTo(1010, 155);
+  context.stroke();
+  context.restore();
+}
+
+function drawPosterPledge(
+  context: CanvasRenderingContext2D,
+  pledgeLines: string[],
+  signatureName: string | null,
+  quoteLayout: ReturnType<typeof getQuoteLayout>,
+) {
+  const lines = withSmartQuotes(pledgeLines);
+  const x = 80;
+  let y = 390;
+
+  context.save();
+  context.fillStyle = "#E6D6BE";
+  context.font = `italic ${quoteLayout.posterFontSize}px ${FONTS.SERIF}`;
+  lines.forEach((line) => {
+    context.fillText(line, x, y);
+    y += quoteLayout.posterLineHeight;
+  });
+
+  if (signatureName) {
+    context.fillStyle = "rgba(230,214,190,0.58)";
+    context.font = `italic ${quoteLayout.posterSignatureFontSize}px ${FONTS.SERIF}`;
+    const fitted = fitCanvasText(context, `— ${signatureName}`, 660);
+    context.fillText(fitted, x + 40, y + quoteLayout.posterSignatureGap);
+  }
+  context.restore();
+}
+
+function drawPosterStats(context: CanvasRenderingContext2D) {
+  context.save();
+  context.font = `500 27px ${FONTS.MONO}`;
+  context.textAlign = "right";
+  context.textBaseline = "alphabetic";
+
+  let y = 1210;
+  SHARE_STATS.forEach(([name, value]) => {
+    const separator = "  ·  ";
+    const valueWidth = context.measureText(value).width;
+    const separatorWidth = context.measureText(separator).width;
+
+    context.fillStyle = "#E6D6BE";
+    context.fillText(value, 980, y);
+    context.fillStyle = "rgba(230,214,190,0.38)";
+    context.fillText(separator, 980 - valueWidth, y);
+    context.fillStyle = "rgba(230,214,190,0.62)";
+    context.fillText(name, 980 - valueWidth - separatorWidth, y);
+    y += 54;
+  });
+  context.restore();
+}
+
+function drawPosterFooter(context: CanvasRenderingContext2D, footerPledgeText: string) {
+  const line = context.createLinearGradient(70, 1695, 1010, 1695);
+  line.addColorStop(0, "rgba(230,214,190,0.15)");
+  line.addColorStop(0.5, "rgba(230,214,190,0.74)");
+  line.addColorStop(1, "rgba(230,214,190,0.15)");
+  context.strokeStyle = line;
+  context.lineWidth = 2;
+  context.beginPath();
+  context.moveTo(70, 1695);
+  context.lineTo(1010, 1695);
+  context.stroke();
+
+  context.save();
+  context.fillStyle = "rgba(230,214,190,0.58)";
+  context.font = `500 19px ${FONTS.MONO}`;
+  context.textAlign = "center";
+  drawLetterSpacedText(context, SITE.domain.toUpperCase(), 540, 1750, 7, "center");
+  drawLetterSpacedText(context, footerPledgeText.toUpperCase(), 540, 1795, 6, "center");
+  context.restore();
+}
+
+function withSmartQuotes(lines: string[]) {
+  if (!lines.length) return lines;
+  return lines.map((line, index) => {
+    if (index === 0 && lines.length === 1) return `“${line}”`;
+    if (index === 0) return `“${line}`;
+    if (index === lines.length - 1) return `${line}”`;
+    return line;
+  });
+}
+
+function fitCanvasText(
+  context: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+) {
+  if (context.measureText(text).width <= maxWidth) return text;
+  let fitted = text;
+  while (fitted.length > 1 && context.measureText(`${fitted}...`).width > maxWidth) {
+    fitted = fitted.slice(0, -1);
+  }
+  return `${fitted.trimEnd()}...`;
+}
+
+function drawLetterSpacedText(
+  context: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  letterSpacing: number,
+  align: "left" | "center" = "left",
+) {
+  const widths = [...text].map((char) => context.measureText(char).width);
+  const totalWidth =
+    widths.reduce((total, width) => total + width, 0) +
+    Math.max(0, text.length - 1) * letterSpacing;
+  let currentX = align === "center" ? x - totalWidth / 2 : x;
+  [...text].forEach((char, index) => {
+    context.fillText(char, currentX, y);
+    currentX += widths[index] + letterSpacing;
+  });
+}
+
+function canvasToPngBlob(canvas: HTMLCanvasElement) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Poster export failed."));
+    }, "image/png");
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.rel = "noopener";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function copyTextToClipboard(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) throw new Error("Clipboard copy failed.");
 }

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const SITE = {
-  name: "Wrapped",
+  name: "Earth Wrapped",
   edition: "MMXXVI",
   domain: "thisyear.earth",
   description:

--- a/constants/quotes.ts
+++ b/constants/quotes.ts
@@ -6,42 +6,41 @@ export const VOICE_QUOTES: Partial<Record<CardId, QuoteSet>> = {
   temp: {
     hopeful: "A tenth of a degree. Small to you. Not to me.",
     default: "A tenth of a degree is never small.",
-    darker: "I'm running a fever. I don't usually.",
+    darker: "I am 0.55°C warmer than I was when your grandparents were born.",
   },
   co2: {
     hopeful: "I've been keeping count. You can help me count down.",
     default: "I've been keeping count since before you had numbers.",
-    darker: "I've been keeping count. The count keeps climbing.",
+    darker: "428 ppm. The last time I was this warm, sea levels were 20 meters higher.",
   },
   ice: {
-    hopeful: "I used to hold so much more. I can again, if you let me.",
+    hopeful: "I lost 1.17 trillion tonnes this year. Less than last year. Keep going.",
     default: "I used to hold so much more.",
-    darker: "I used to hold so much more. It's running now. Into you.",
+    darker: "1.17 trillion tonnes. Gone into the ocean. Into the coasts. Into your cities.",
   },
   forest: {
-    hopeful: "They grew back before. With time. With help, maybe sooner.",
+    hopeful: "They grew back after the last extinction. They can again.",
     default: "They were here before your grandparents' grandparents.",
-    darker:
-      "They were here before your grandparents' grandparents. Now they are smoke.",
+    darker: "14.9 million hectares. Every second of this year, I lost an area the size of a football pitch.",
   },
   species: {
-    hopeful: "I knew each one. I'm hoping I won't have to unknow them.",
+    hopeful: "I knew each one. Some I may know again, if you give them room.",
     default: "I knew each one. Now I'm learning to unknow them.",
-    darker: "I knew each one. I'm learning to unknow them.",
+    darker: "41,046 species threatened. I am losing them 1,000 times faster than before you arrived.",
   },
   plastic: {
-    hopeful: "It outlives us all. But you invented it. You can uninvent some of it.",
-    default: "It outlives us all. Even me, for a little while.",
-    darker: "It outlives us all. Your bones will be gone. Your straws will be here.",
+    hopeful: "413 million tonnes made this year. You recycled 9% of it. That number can grow.",
+    default: "It outlives you. By centuries.",
+    darker: "413 million tonnes. 9% recycled. The rest is in me. In the fish. In you.",
   },
   renewables: {
     hopeful: "You're trying. I see it. Keep going.",
     default: "You're trying. I see it. Keep going.",
-    darker: "You're trying. It's not enough yet. But I see it.",
+    darker: "32% more clean energy. Still 80% of your power from fossil fuels. I see both numbers.",
   },
   final: {
-    hopeful: "Another year recorded. See you next year.\nMake it count with me.",
-    default: "Another year recorded. See you next year.\nMake it count.",
-    darker: "Another year recorded.\nThere may not be endless others.",
+    hopeful: "Another year recorded. See you next year. Make it count.",
+    default: "Another year recorded. See you next year. \nMake it count.",
+    darker: "Another year recorded. \nThe window is narrowing. I am still here. For now.",
   },
 };


### PR DESCRIPTION
## Summary

Polish the Earth Wrapped share artifact into a stable, export-safe poster and make the share sheet actions actually usable.

## What changed

- improved the share poster export so the dark Earth Wrapped treatment survives image generation
- refined quote/layout behavior for longer custom pledges
- preserved optional signer behavior so the poster still looks clean when no name is provided
- tuned footer/ledger presentation, including low-count display behavior
- wired the share sheet actions so they no longer act like no-ops
- updated supporting metadata and copy used by share/export flows
- refreshed related climate card/source text that feeds the poster context

## Validation

- poster export now preserves the intended dark visual identity
- share actions are wired with real behavior and fallbacks
- longer custom pledges fit more gracefully without breaking composition
