### PR TITLE
feat(solana): add devnet pledge mint flow and Neon-backed ledger

### DIFF
--- a/app/api/pledges/route.ts
+++ b/app/api/pledges/route.ts
@@ -1,11 +1,23 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { PLEDGE_COUNT_CACHE_TAG, cachedCountPledges, insertPledge } from "@/lib/db/pledges";
+import {
+  PLEDGE_COUNT_CACHE_TAG,
+  cachedCountPledges,
+  insertPledge,
+  listMintedPledges,
+} from "@/lib/db/pledges";
 import { recordLocation } from "@/lib/db/locations";
-import { mintPledge } from "@/lib/solana/mint";
+import { fetchLatestCo2 } from "@/lib/api/co2";
 import type { Pledge } from "@/types";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
 import { revalidateTag } from "next/cache";
+import {
+  isLikelySolanaSignature,
+  isValidPledgeMintMetadata,
+  SOLANA_MEMO_PROGRAM_ID,
+  SOLANA_NETWORK,
+  type PledgeMintMetadata,
+} from "@/lib/solana/mint";
 
 function optionalCoordinate(value: unknown, min: number, max: number): number | null {
   if (value === null || value === undefined || value === "") return null;
@@ -14,9 +26,66 @@ function optionalCoordinate(value: unknown, min: number, max: number): number | 
   return n;
 }
 
-export async function GET() {
+function optionalMintMetadata(value: unknown, pledgeText: string): PledgeMintMetadata | null {
+  if (!value || typeof value !== "object") return null;
+  const mint = value as Partial<PledgeMintMetadata>;
+  if (
+    typeof mint.txHash !== "string" ||
+    typeof mint.walletAddress !== "string" ||
+    typeof mint.memo !== "string" ||
+    typeof mint.explorerUrl !== "string" ||
+    typeof mint.mintedAt !== "string"
+  ) {
+    return null;
+  }
+
+  const metadata: PledgeMintMetadata = {
+    txHash: mint.txHash,
+    network: mint.network === SOLANA_NETWORK ? mint.network : SOLANA_NETWORK,
+    walletAddress: mint.walletAddress,
+    memo: mint.memo,
+    memoProgramId:
+      mint.memoProgramId === SOLANA_MEMO_PROGRAM_ID
+        ? mint.memoProgramId
+        : SOLANA_MEMO_PROGRAM_ID,
+    explorerUrl: mint.explorerUrl,
+    mintedAt: mint.mintedAt,
+  };
+
+  if (!isLikelySolanaSignature(metadata.txHash)) return null;
+  if (!isValidPledgeMintMetadata(metadata, pledgeText)) return null;
+  return metadata;
+}
+
+export async function GET(req: NextRequest) {
   const count = await cachedCountPledges();
-  return NextResponse.json({ count });
+  if (req.nextUrl.searchParams.get("ledger") !== "1") {
+    return NextResponse.json({ count });
+  }
+
+  const limit = Number(req.nextUrl.searchParams.get("limit") ?? 50);
+  const pledges = await listMintedPledges(Number.isFinite(limit) ? limit : 50);
+  return NextResponse.json({
+    count,
+    pledges: pledges.map((pledge) => ({
+      id: pledge.id,
+      pledgeText: pledge.pledgeText,
+      name: pledge.name,
+      country: pledge.country,
+      countryCode: pledge.countryCode,
+      createdAt: pledge.createdAt,
+      minted: pledge.mintStatus === "minted",
+      txHash: pledge.txHash,
+      mintStatus: pledge.mintStatus,
+      co2PpmAtMint: pledge.co2PpmAtMint,
+      mintNetwork: pledge.mintNetwork,
+      walletAddress: pledge.walletAddress,
+      mintMemo: pledge.mintMemo,
+      memoProgramId: pledge.memoProgramId,
+      explorerUrl: pledge.explorerUrl,
+      mintedAt: pledge.mintedAt,
+    })),
+  });
 }
 
 export async function POST(req: NextRequest) {
@@ -28,6 +97,7 @@ export async function POST(req: NextRequest) {
     country_code?: unknown;
     countryCode?: unknown;
     location?: unknown;
+    mint?: unknown;
   };
   try {
     body = await req.json();
@@ -67,7 +137,11 @@ export async function POST(req: NextRequest) {
         })
       : null;
 
-  const result = await mintPledge(pledgeText);
+  const mint = optionalMintMetadata(body.mint, pledgeText);
+  if (body.mint !== undefined && !mint) {
+    return NextResponse.json({ error: "invalid mint metadata" }, { status: 400 });
+  }
+  const co2PpmAtMint = mint ? (await fetchLatestCo2()).ppm : null;
   let saved: Awaited<ReturnType<typeof insertPledge>>;
   try {
     saved = await insertPledge({
@@ -75,6 +149,8 @@ export async function POST(req: NextRequest) {
       name: name || null,
       country: country || null,
       countryCode: countryCode || null,
+      mint,
+      co2PpmAtMint,
     });
   } catch (error) {
     console.error("Failed to insert pledge", error);
@@ -113,9 +189,17 @@ export async function POST(req: NextRequest) {
     name: saved.name,
     country: saved.country,
     countryCode: saved.countryCode,
-    minted: true,
+    minted: saved.mintStatus === "minted",
     ts: Date.now(),
-    txHash: result.txHash,
+    txHash: saved.txHash ?? undefined,
+    mintStatus: saved.mintStatus,
+    co2PpmAtMint: saved.co2PpmAtMint,
+    mintNetwork: saved.mintNetwork ?? undefined,
+    walletAddress: saved.walletAddress,
+    mintMemo: saved.mintMemo,
+    memoProgramId: saved.memoProgramId,
+    explorerUrl: saved.explorerUrl,
+    mintedAt: saved.mintedAt,
   };
   return NextResponse.json({ pledge });
 }

--- a/app/ledger/page.tsx
+++ b/app/ledger/page.tsx
@@ -1,0 +1,173 @@
+import { FONTS, PALETTE } from "@/constants/colors";
+import { SITE } from "@/config/site";
+import { listMintedPledges } from "@/lib/db/pledges";
+import { getSolanaDevnetExplorerUrl } from "@/lib/solana/mint";
+import { connection } from "next/server";
+import { Suspense } from "react";
+import type { ReactNode } from "react";
+
+function formatDate(value: Date | string | null) {
+  if (!value) return "pending";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "pending";
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function shortHash(value: string) {
+  return `${value.slice(0, 6)}...${value.slice(-6)}`;
+}
+
+function EmptyLedgerMessage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        padding: "28px 0",
+        borderTop: "1px solid rgba(230,214,190,0.18)",
+        fontFamily: FONTS.MONO,
+        fontSize: 11,
+        letterSpacing: "0.2em",
+        textTransform: "uppercase",
+        color: PALETTE.ASH_DIM,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+async function LedgerEntries() {
+  await connection();
+  const pledges = await listMintedPledges(100);
+
+  if (pledges.length === 0) {
+    return <EmptyLedgerMessage>No devnet proofs recorded yet.</EmptyLedgerMessage>;
+  }
+
+  return pledges.map((pledge) => {
+    const txHash = pledge.txHash;
+    const href =
+      pledge.explorerUrl ?? (txHash ? getSolanaDevnetExplorerUrl(txHash) : null);
+
+    return (
+      <article
+        key={pledge.id}
+        style={{
+          display: "grid",
+          gridTemplateColumns: "minmax(0, 1fr) auto",
+          gap: 18,
+          alignItems: "start",
+          padding: "18px 0",
+          borderTop: "1px solid rgba(230,214,190,0.16)",
+        }}
+      >
+        <div>
+          <div
+            style={{
+              fontFamily: FONTS.SERIF,
+              fontSize: "clamp(22px, 4vw, 34px)",
+              lineHeight: 1.15,
+              fontStyle: "italic",
+              color: PALETTE.ASH,
+            }}
+          >
+            &ldquo;{pledge.pledgeText}&rdquo;
+          </div>
+          <div
+            style={{
+              marginTop: 10,
+              fontFamily: FONTS.MONO,
+              fontSize: 10,
+              lineHeight: 1.8,
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+              color: PALETTE.ASH_DIM,
+            }}
+          >
+            {pledge.name ? `Signed ${pledge.name}` : "Unsigned"} ·{" "}
+            {formatDate(pledge.mintedAt)}
+            {pledge.co2PpmAtMint ? ` · ${pledge.co2PpmAtMint} ppm` : ""}
+          </div>
+        </div>
+
+        {href && txHash && (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              fontFamily: FONTS.MONO,
+              fontSize: 10,
+              letterSpacing: "0.18em",
+              textTransform: "uppercase",
+              color: PALETTE.ASH,
+              textDecoration: "none",
+              whiteSpace: "nowrap",
+            }}
+          >
+            TX · {shortHash(txHash)}
+          </a>
+        )}
+      </article>
+    );
+  });
+}
+
+export default function LedgerPage() {
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        padding: "56px max(24px, 6vw)",
+        background: `linear-gradient(180deg, ${PALETTE.BG_TOP}, ${PALETTE.BG_BOTTOM})`,
+        color: PALETTE.ASH,
+      }}
+    >
+      <header style={{ maxWidth: 980, margin: "0 auto 42px" }}>
+        <div
+          style={{
+            fontFamily: FONTS.MONO,
+            fontSize: 10,
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+            color: PALETTE.ASH_DIM,
+            marginBottom: 14,
+          }}
+        >
+          {SITE.name} · Devnet Proof Ledger
+        </div>
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: FONTS.SERIF,
+            fontSize: "clamp(42px, 8vw, 92px)",
+            lineHeight: 0.95,
+            fontStyle: "italic",
+            fontWeight: 400,
+            letterSpacing: 0,
+          }}
+        >
+          Pledges minted
+          <br />
+          to Solana.
+        </h1>
+      </header>
+
+      <section
+        style={{
+          maxWidth: 980,
+          margin: "0 auto",
+          display: "grid",
+          gap: 10,
+        }}
+      >
+        <Suspense fallback={<EmptyLedgerMessage>Loading devnet proofs.</EmptyLedgerMessage>}>
+          <LedgerEntries />
+        </Suspense>
+      </section>
+    </main>
+  );
+}

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -41,7 +41,7 @@ export function PledgeCard({
   const [whereFrom, setWhereFrom] = useState(userPledge?.country ?? "");
   const [writing, setWriting] = useState(false);
   const minted = !!userPledge?.minted;
-  const { mint, minting } = useMintPledge();
+  const { mint, record, minting, error } = useMintPledge();
   const isDesktop = useMediaMin(1024);
 
   const pledgeText = useMemo(() => {
@@ -70,21 +70,27 @@ export function PledgeCard({
     }
   };
 
-  const handleSkipMint = () => {
+  const handleSkipMint = async () => {
     if (!canMint) {
       onNext();
       return;
     }
-    onPledge({
-      choice: writing ? null : choice,
-      custom: writing ? custom : null,
+    const result = await record(pledgeText, {
       name: name.trim() || null,
       country: whereFrom.trim() || null,
-      countryCode: null,
-      minted: false,
-      ts: Date.now(),
+      location: userLocation,
     });
-    onNext();
+    if (result) {
+      onPledge({
+        ...result,
+        choice: writing ? null : choice,
+        custom: writing ? custom : null,
+        name: result.name ?? (name.trim() || null),
+        country: result.country ?? (whereFrom.trim() || null),
+        minted: false,
+      });
+      onNext();
+    }
   };
 
   return (
@@ -407,8 +413,25 @@ export function PledgeCard({
                 color: PALETTE.ASH_DIMMER,
               }}
             >
-              Pledges recorded on Solana · Anonymous
+              Solana devnet is optional
             </div>
+            {error && (
+              <div
+                role="status"
+                style={{
+                  marginTop: 10,
+                  textAlign: "center",
+                  fontFamily: FONTS.MONO,
+                  fontSize: 8,
+                  lineHeight: 1.5,
+                  letterSpacing: "0.16em",
+                  textTransform: "uppercase",
+                  color: accent.hex,
+                }}
+              >
+                {error}
+              </div>
+            )}
           </div>
         </>
       ) : (

--- a/components/ui/ShareSheet.tsx
+++ b/components/ui/ShareSheet.tsx
@@ -217,7 +217,7 @@ function Sheet({
         style={{
           width: isDesktop ? "min(460px, calc(100vw - 48px))" : "100%",
           maxHeight: isDesktop ? "calc(100dvh - 48px)" : "100dvh",
-          overflowY: isDesktop ? "auto" : "hidden",
+          overflow: "hidden",
           overscrollBehavior: "contain",
           borderRadius: isDesktop ? 18 : "24px 24px 0 0",
           background: "linear-gradient(180deg, #0e1220 0%, #070a12 100%)",
@@ -253,7 +253,7 @@ function Sheet({
           style={{
             width: "100%",
             maxWidth: isDesktop
-              ? 420
+              ? "min(420px, calc((100dvh - 250px) * 9 / 14))"
               : "min(100%, 360px, calc((100dvh - 300px) * 9 / 14))",
             margin: isDesktop ? "0 auto 14px" : "0 auto 16px",
             aspectRatio: "9 / 14",

--- a/hooks/usePledge.ts
+++ b/hooks/usePledge.ts
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { ENDPOINTS } from "@/constants/endpoints";
 import type { Pledge } from "@/types";
+import { mintPledgeOnDevnet } from "@/lib/solana/wallet";
+import type { PledgeMintMetadata } from "@/lib/solana/mint";
 
 const SESSION_LOCATION_KEY = "thisyearearth:session-location";
 const SAVED_LOCATION_KEY = "thisyearearth:session-location-saved";
@@ -102,35 +104,71 @@ export function useMintPledge() {
   const [minting, setMinting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const postPledge = useCallback(
+    async (
+      text: string,
+      metadata: PledgeMetadata = {},
+      mintMetadata?: PledgeMintMetadata,
+    ): Promise<Pledge | null> => {
+      const res = await fetch(ENDPOINTS.PLEDGES, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pledge_text: text,
+          name: metadata.name,
+          country: metadata.country,
+          countryCode: metadata.countryCode,
+          location: metadata.location,
+          mint: mintMetadata,
+        }),
+      });
+      if (!res.ok) throw new Error(`pledge save failed: ${res.status}`);
+      const data = (await res.json()) as { pledge: Pledge };
+      return data.pledge;
+    },
+    [],
+  );
+
   const mint = useCallback(
     async (text: string, metadata: PledgeMetadata = {}): Promise<Pledge | null> => {
       setMinting(true);
       setError(null);
+      let mintMetadata: PledgeMintMetadata | null = null;
       try {
-        const res = await fetch(ENDPOINTS.PLEDGES, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            pledge_text: text,
-            name: metadata.name,
-            country: metadata.country,
-            countryCode: metadata.countryCode,
-            location: metadata.location,
-          }),
-        });
-        if (!res.ok) throw new Error(`mint failed: ${res.status}`);
+        mintMetadata = await mintPledgeOnDevnet(text);
         await ensureSessionLocationSaved();
-        const data = (await res.json()) as { pledge: Pledge };
-        return data.pledge;
+        return postPledge(text, metadata, mintMetadata);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "mint failed");
+        const message = e instanceof Error ? e.message : "mint failed";
+        setError(
+          mintMetadata
+            ? `Solana confirmed, but pledge save failed: ${message}`
+            : message,
+        );
         return null;
       } finally {
         setMinting(false);
       }
     },
-    [],
+    [postPledge],
   );
 
-  return { mint, minting, error };
+  const record = useCallback(
+    async (text: string, metadata: PledgeMetadata = {}): Promise<Pledge | null> => {
+      setMinting(true);
+      setError(null);
+      try {
+        await ensureSessionLocationSaved();
+        return postPledge(text, metadata);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "pledge save failed");
+        return null;
+      } finally {
+        setMinting(false);
+      }
+    },
+    [postPledge],
+  );
+
+  return { mint, record, minting, error };
 }

--- a/lib/db/pledges.ts
+++ b/lib/db/pledges.ts
@@ -1,8 +1,11 @@
 import { getSql } from "./client";
 import { cacheLife, cacheTag } from "next/cache";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
+import type { PledgeMintMetadata, SolanaNetwork } from "@/lib/solana/mint";
 
 export const PLEDGE_COUNT_CACHE_TAG = "pledge-count";
+
+export type MintStatus = "none" | "minted";
 
 export type PledgeRow = {
   id: string;
@@ -11,6 +14,15 @@ export type PledgeRow = {
   country: string | null;
   countryCode: string | null;
   createdAt: Date | string;
+  txHash: string | null;
+  mintStatus: MintStatus;
+  walletAddress: string | null;
+  co2PpmAtMint: number | null;
+  mintNetwork: SolanaNetwork | null;
+  mintMemo: string | null;
+  memoProgramId: string | null;
+  explorerUrl: string | null;
+  mintedAt: Date | string | null;
 };
 
 let memoryStore: PledgeRow[] = [];
@@ -20,7 +32,47 @@ type InsertPledgeInput = {
   name?: string | null;
   country?: string | null;
   countryCode?: string | null;
+  mint?: PledgeMintMetadata | null;
+  co2PpmAtMint?: number | null;
 };
+
+type PledgeDbRow = {
+  id: string;
+  pledge_text: string;
+  name: string | null;
+  country: string | null;
+  country_code: string | null;
+  created_at: Date | string;
+  tx_hash: string | null;
+  mint_status: MintStatus;
+  minted_at: Date | string | null;
+  co2_ppm_at_mint: number | null;
+  mint_network: SolanaNetwork | null;
+  wallet_address: string | null;
+  mint_memo: string | null;
+  memo_program_id: string | null;
+  explorer_url: string | null;
+};
+
+function mapPledgeRow(row: PledgeDbRow): PledgeRow {
+  return {
+    id: row.id,
+    pledgeText: row.pledge_text,
+    name: row.name,
+    country: row.country,
+    countryCode: row.country_code,
+    createdAt: row.created_at,
+    txHash: row.tx_hash,
+    mintStatus: row.mint_status,
+    mintedAt: row.minted_at,
+    co2PpmAtMint: row.co2_ppm_at_mint,
+    mintNetwork: row.mint_network,
+    walletAddress: row.wallet_address,
+    mintMemo: row.mint_memo,
+    memoProgramId: row.memo_program_id,
+    explorerUrl: row.explorer_url,
+  };
+}
 
 export async function insertPledge(input: InsertPledgeInput): Promise<PledgeRow> {
   if (input.pledgeText.length < PLEDGE_TEXT_MIN_LENGTH) {
@@ -37,6 +89,15 @@ export async function insertPledge(input: InsertPledgeInput): Promise<PledgeRow>
     country: input.country ?? null,
     countryCode: input.countryCode ?? null,
     createdAt: new Date().toISOString(),
+    txHash: input.mint?.txHash ?? null,
+    mintStatus: input.mint ? "minted" : "none",
+    mintedAt: input.mint?.mintedAt ?? null,
+    co2PpmAtMint: input.co2PpmAtMint ?? null,
+    mintNetwork: input.mint?.network ?? null,
+    walletAddress: input.mint?.walletAddress ?? null,
+    mintMemo: input.mint?.memo ?? null,
+    memoProgramId: input.mint?.memoProgramId ?? null,
+    explorerUrl: input.mint?.explorerUrl ?? null,
   };
 
   const sql = getSql();
@@ -46,28 +107,57 @@ export async function insertPledge(input: InsertPledgeInput): Promise<PledgeRow>
   }
 
   const rows = (await sql`
-    INSERT INTO pledges (pledge_text, name, country, country_code)
-    VALUES (${row.pledgeText}, ${row.name}, ${row.country}, ${row.countryCode})
-    RETURNING id, pledge_text, name, country, country_code, created_at
-  `) as {
-    id: string;
-    pledge_text: string;
-    name: string | null;
-    country: string | null;
-    country_code: string | null;
-    created_at: Date | string;
-  }[];
+    INSERT INTO pledges (
+      pledge_text,
+      name,
+      country,
+      country_code,
+      tx_hash,
+      mint_status,
+      minted_at,
+      co2_ppm_at_mint,
+      mint_network,
+      wallet_address,
+      mint_memo,
+      memo_program_id,
+      explorer_url
+    )
+    VALUES (
+      ${row.pledgeText},
+      ${row.name},
+      ${row.country},
+      ${row.countryCode},
+      ${row.txHash},
+      ${row.mintStatus},
+      ${row.mintedAt},
+      ${row.co2PpmAtMint},
+      ${row.mintNetwork},
+      ${row.walletAddress},
+      ${row.mintMemo},
+      ${row.memoProgramId},
+      ${row.explorerUrl}
+    )
+    RETURNING
+      id,
+      pledge_text,
+      name,
+      country,
+      country_code,
+      created_at,
+      tx_hash,
+      mint_status,
+      minted_at,
+      co2_ppm_at_mint,
+      mint_network,
+      wallet_address,
+      mint_memo,
+      memo_program_id,
+      explorer_url
+  `) as PledgeDbRow[];
 
   const saved = rows[0];
   if (!saved) return row;
-  return {
-    id: saved.id,
-    pledgeText: saved.pledge_text,
-    name: saved.name,
-    country: saved.country,
-    countryCode: saved.country_code,
-    createdAt: saved.created_at,
-  };
+  return mapPledgeRow(saved);
 }
 
 export async function countPledges(): Promise<number> {
@@ -77,6 +167,41 @@ export async function countPledges(): Promise<number> {
     n: number;
   }[];
   return rows[0]?.n ?? 0;
+}
+
+export async function listMintedPledges(limit = 50): Promise<PledgeRow[]> {
+  const safeLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
+  const sql = getSql();
+  if (!sql) {
+    return memoryStore
+      .filter((pledge) => pledge.mintStatus === "minted" && pledge.txHash)
+      .slice(0, safeLimit);
+  }
+
+  const rows = (await sql`
+    SELECT
+      id,
+      pledge_text,
+      name,
+      country,
+      country_code,
+      created_at,
+      tx_hash,
+      mint_status,
+      minted_at,
+      co2_ppm_at_mint,
+      mint_network,
+      wallet_address,
+      mint_memo,
+      memo_program_id,
+      explorer_url
+    FROM pledges
+    WHERE mint_status = 'minted' AND tx_hash IS NOT NULL
+    ORDER BY minted_at DESC, created_at DESC
+    LIMIT ${safeLimit}
+  `) as PledgeDbRow[];
+
+  return rows.map(mapPledgeRow);
 }
 
 export async function cachedCountPledges(): Promise<number> {

--- a/lib/solana/mint.ts
+++ b/lib/solana/mint.ts
@@ -1,20 +1,72 @@
-const HEX = "0123456789ABCDEF";
+const configuredSolanaNetwork =
+  process.env.NEXT_PUBLIC_SOLANA_NETWORK?.trim().toLowerCase() || "devnet";
 
-function randomHex(len: number): string {
-  let out = "";
-  for (let i = 0; i < len; i++) out += HEX[Math.floor(Math.random() * 16)];
-  return out;
+export type SolanaNetwork = "devnet" | "testnet";
+
+function normalizeSolanaNetwork(value: string): SolanaNetwork {
+  return value === "testnet" ? "testnet" : "devnet";
 }
 
-export type MintResult = {
+function defaultRpcUrl(network: SolanaNetwork) {
+  return `https://api.${network}.solana.com`;
+}
+
+export const SOLANA_NETWORK = normalizeSolanaNetwork(configuredSolanaNetwork);
+export const SOLANA_CONFIGURED_NETWORK = configuredSolanaNetwork;
+export const SOLANA_RPC_URL =
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL?.trim() ||
+  defaultRpcUrl(SOLANA_NETWORK);
+export const SOLANA_DEVNET_RPC_URL = SOLANA_RPC_URL;
+export const SOLANA_MEMO_PROGRAM_ID =
+  "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+export const PLEDGE_MEMO_VERSION = 1;
+export const SOLANA_DEBUG_MEMO_ENABLED =
+  process.env.NEXT_PUBLIC_SOLANA_DEBUG_MEMO === "1";
+
+export type PledgeMintMetadata = {
   txHash: string;
-  network: "devnet" | "mainnet" | "stub";
+  network: SolanaNetwork;
+  walletAddress: string;
+  memo: string;
+  memoProgramId: typeof SOLANA_MEMO_PROGRAM_ID;
+  explorerUrl: string;
+  mintedAt: string;
 };
 
-export async function mintPledge(text: string): Promise<MintResult> {
-  void text;
-  return {
-    txHash: `${randomHex(8)}…${randomHex(6)}`,
-    network: "stub",
-  };
+export function buildPledgeMemo(pledgeText: string) {
+  if (SOLANA_DEBUG_MEMO_ENABLED) return "earth-wrapped-test";
+
+  return JSON.stringify({
+    app: "thisyear.earth",
+    type: "earth-pledge",
+    version: PLEDGE_MEMO_VERSION,
+    pledge: pledgeText,
+  });
+}
+
+export function getSolanaDevnetExplorerUrl(txHash: string) {
+  return `https://explorer.solana.com/tx/${txHash}?cluster=${SOLANA_NETWORK}`;
+}
+
+export function isLikelySolanaSignature(value: string) {
+  return /^[1-9A-HJ-NP-Za-km-z]{64,88}$/.test(value);
+}
+
+export function isLikelySolanaPublicKey(value: string) {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value);
+}
+
+export function isValidPledgeMintMetadata(
+  value: PledgeMintMetadata,
+  pledgeText: string,
+) {
+  return (
+    value.network === SOLANA_NETWORK &&
+    value.memoProgramId === SOLANA_MEMO_PROGRAM_ID &&
+    value.explorerUrl === getSolanaDevnetExplorerUrl(value.txHash) &&
+    isLikelySolanaSignature(value.txHash) &&
+    isLikelySolanaPublicKey(value.walletAddress) &&
+    Number.isFinite(Date.parse(value.mintedAt)) &&
+    value.memo === buildPledgeMemo(pledgeText)
+  );
 }

--- a/lib/solana/wallet.ts
+++ b/lib/solana/wallet.ts
@@ -1,0 +1,270 @@
+"use client";
+
+import {
+  Connection,
+  PublicKey,
+  TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+import { Buffer } from "buffer";
+import {
+  buildPledgeMemo,
+  getSolanaDevnetExplorerUrl,
+  SOLANA_CONFIGURED_NETWORK,
+  SOLANA_DEBUG_MEMO_ENABLED,
+  SOLANA_MEMO_PROGRAM_ID,
+  SOLANA_NETWORK,
+  SOLANA_RPC_URL,
+  type PledgeMintMetadata,
+} from "./mint";
+
+const MIN_TEST_CLUSTER_FEE_LAMPORTS = 10_000;
+
+type WalletConnectResult = {
+  publicKey?: { toString: () => string };
+};
+
+type SolanaWalletProvider = {
+  isConnected?: boolean;
+  publicKey?: { toString: () => string };
+  connect: () => Promise<WalletConnectResult>;
+  signAndSendTransaction?: (
+    transaction: VersionedTransaction,
+  ) => Promise<{ signature: string }>;
+  signTransaction?: (
+    transaction: VersionedTransaction,
+  ) => Promise<VersionedTransaction>;
+};
+
+declare global {
+  interface Window {
+    solana?: SolanaWalletProvider & {
+      isPhantom?: boolean;
+      isSolflare?: boolean;
+    };
+    phantom?: {
+      solana?: SolanaWalletProvider & {
+        isPhantom?: boolean;
+      };
+    };
+  }
+}
+
+function getBrowserWalletProvider() {
+  if (typeof window === "undefined") return null;
+  return window.phantom?.solana ?? window.solana ?? null;
+}
+
+function logSolanaDebug(
+  scope: string,
+  details: Record<string, unknown>,
+) {
+  console.info(`[solana:${scope}]`, details);
+}
+
+function logSimulation(scope: string, value: unknown) {
+  console.info(`[solana:${scope}]`, value);
+}
+
+function isWalletRejection(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+  const { code, message } = error as { code?: unknown; message?: unknown };
+  return (
+    code === 4001 ||
+    (typeof message === "string" &&
+      message.toLowerCase().includes("user rejected"))
+  );
+}
+
+async function logSolanaError(
+  scope: string,
+  error: unknown,
+  connection?: Connection,
+) {
+  console.error(`[solana:${scope}]`, error);
+  if (error && typeof error === "object") {
+    const maybeLogs = (error as { logs?: unknown }).logs;
+    if (maybeLogs) console.error(`[solana:${scope}:logs]`, maybeLogs);
+    const maybeGetLogs = (error as {
+      getLogs?: (connection: Connection) => Promise<unknown>;
+    }).getLogs;
+    if (connection && typeof maybeGetLogs === "function") {
+      try {
+        console.error(`[solana:${scope}:logs]`, await maybeGetLogs(connection));
+      } catch {
+        // The original error above is the important one.
+      }
+    }
+  }
+}
+
+async function connectWallet(provider: SolanaWalletProvider) {
+  let connectedPublicKey = provider.publicKey?.toString();
+  if (!provider.publicKey || !provider.isConnected) {
+    const result = await provider.connect();
+    connectedPublicKey = result.publicKey?.toString() ?? provider.publicKey?.toString();
+  }
+  const publicKey = connectedPublicKey ?? provider.publicKey?.toString();
+  if (!publicKey) throw new Error("Wallet connection failed.");
+  return publicKey;
+}
+
+async function simulateUnsignedTransaction({
+  connection,
+  feePayer,
+  recentBlockhash,
+  instruction,
+}: {
+  connection: Connection;
+  feePayer: PublicKey;
+  recentBlockhash: string;
+  instruction: TransactionInstruction;
+}) {
+  const message = new TransactionMessage({
+    payerKey: feePayer,
+    recentBlockhash,
+    instructions: [instruction],
+  }).compileToV0Message();
+  const simulation = await connection.simulateTransaction(
+    new VersionedTransaction(message),
+    {
+      sigVerify: false,
+      commitment: "confirmed",
+    },
+  );
+
+  logSimulation("preflight", {
+    err: simulation.value.err,
+    logs: simulation.value.logs,
+    unitsConsumed: simulation.value.unitsConsumed,
+  });
+
+  if (simulation.value.err) {
+    throw new Error(
+      `Solana preflight simulation failed: ${JSON.stringify(simulation.value.err)}`,
+    );
+  }
+}
+
+export async function mintPledgeOnDevnet(
+  pledgeText: string,
+): Promise<PledgeMintMetadata> {
+  const provider = getBrowserWalletProvider();
+  if (!provider) {
+    throw new Error("Install Phantom or Solflare to mint on Solana.");
+  }
+
+  const walletAddress = await connectWallet(provider);
+  const connection = new Connection(SOLANA_RPC_URL, "confirmed");
+  const feePayer = new PublicKey(walletAddress);
+  const balance = await connection.getBalance(feePayer, "confirmed");
+  if (balance < MIN_TEST_CLUSTER_FEE_LAMPORTS) {
+    throw new Error(
+      `Wallet needs ${SOLANA_NETWORK} SOL before minting. Add ${SOLANA_NETWORK} SOL in Phantom and try again.`,
+    );
+  }
+
+  const memo = buildPledgeMemo(pledgeText);
+  const memoPayload = Buffer.from(new TextEncoder().encode(memo));
+  const latestBlockhash = await connection.getLatestBlockhash("confirmed");
+  const genesisHash = await connection.getGenesisHash().catch(() => null);
+  const memoInstruction = new TransactionInstruction({
+    keys: [],
+    programId: new PublicKey(SOLANA_MEMO_PROGRAM_ID),
+    data: memoPayload,
+  });
+  const message = new TransactionMessage({
+    payerKey: feePayer,
+    recentBlockhash: latestBlockhash.blockhash,
+    instructions: [memoInstruction],
+  }).compileToV0Message();
+  const transaction = new VersionedTransaction(message);
+
+  logSolanaDebug("prepare", {
+    walletAddress,
+    rpcUrl: SOLANA_RPC_URL,
+    network: SOLANA_NETWORK,
+    configuredNetwork: SOLANA_CONFIGURED_NETWORK,
+    genesisHash,
+    balanceLamports: balance,
+    recentBlockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    memo,
+    memoBytes: memoPayload.length,
+    debugMemo: SOLANA_DEBUG_MEMO_ENABLED,
+    transactionVersion: 0,
+    instructionProgramIds: [memoInstruction.programId.toBase58()],
+    instructionKeys: [memoInstruction.keys],
+  });
+
+  let txHash: string;
+  let appPreflightPassed = false;
+  try {
+    await simulateUnsignedTransaction({
+      connection,
+      feePayer,
+      recentBlockhash: latestBlockhash.blockhash,
+      instruction: memoInstruction,
+    });
+    appPreflightPassed = true;
+
+    if (provider.signTransaction) {
+      const signed = await provider.signTransaction(transaction);
+      const simulation = await connection.simulateTransaction(signed, {
+        sigVerify: true,
+        commitment: "confirmed",
+      });
+      if (simulation.value.err) {
+        console.error("[solana:simulate:logs]", simulation.value.logs);
+        console.error("[solana:simulate:error]", simulation.value.err);
+        throw new Error(`Solana simulation failed: ${JSON.stringify(simulation.value.err)}`);
+      }
+      txHash = await connection.sendRawTransaction(signed.serialize(), {
+        preflightCommitment: "confirmed",
+        maxRetries: 3,
+      });
+    } else if (provider.signAndSendTransaction) {
+      const result = await provider.signAndSendTransaction(transaction);
+      txHash = result.signature;
+    } else {
+      throw new Error("Wallet does not support transaction signing.");
+    }
+  } catch (error) {
+    if (isWalletRejection(error)) {
+      throw new Error("Mint cancelled.");
+    }
+    if (appPreflightPassed) {
+      await logSolanaError("wallet-preflight", error, connection);
+      throw new Error(
+        `Phantom rejected this after ${SOLANA_NETWORK} preflight passed. Confirm Phantom is set to ${SOLANA_NETWORK}, then try again.`,
+      );
+    }
+    await logSolanaError("send", error, connection);
+    throw error;
+  }
+
+  try {
+    await connection.confirmTransaction(
+      {
+        signature: txHash,
+        blockhash: latestBlockhash.blockhash,
+        lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+      },
+      "confirmed",
+    );
+  } catch (error) {
+    await logSolanaError("confirm", error, connection);
+    throw error;
+  }
+
+  return {
+    txHash,
+    network: SOLANA_NETWORK,
+    walletAddress,
+    memo,
+    memoProgramId: SOLANA_MEMO_PROGRAM_ID,
+    explorerUrl: getSolanaDevnetExplorerUrl(txHash),
+    mintedAt: new Date().toISOString(),
+  };
+}

--- a/migrations/001_add_pledge_mint_metadata.sql
+++ b/migrations/001_add_pledge_mint_metadata.sql
@@ -1,0 +1,27 @@
+ALTER TABLE pledges
+  ADD COLUMN IF NOT EXISTS tx_hash TEXT,
+  ADD COLUMN IF NOT EXISTS mint_status TEXT NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS minted_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS co2_ppm_at_mint INTEGER,
+  ADD COLUMN IF NOT EXISTS mint_network TEXT,
+  ADD COLUMN IF NOT EXISTS wallet_address TEXT,
+  ADD COLUMN IF NOT EXISTS mint_memo TEXT,
+  ADD COLUMN IF NOT EXISTS memo_program_id TEXT,
+  ADD COLUMN IF NOT EXISTS explorer_url TEXT;
+
+DO $$
+BEGIN
+  ALTER TABLE pledges
+    ADD CONSTRAINT pledges_mint_status_check
+    CHECK (mint_status IN ('none', 'minted'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pledges_tx_hash_unique
+  ON pledges (tx_hash)
+  WHERE tx_hash IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS pledges_minted_ledger_idx
+  ON pledges (minted_at DESC, created_at DESC)
+  WHERE mint_status = 'minted' AND tx_hash IS NOT NULL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.1.0",
+        "@solana/web3.js": "^1.98.4",
         "@studio-freight/lenis": "^1.0.42",
+        "buffer": "^6.0.3",
         "framer-motion": "^12.38.0",
         "next": "16.2.4",
         "react": "19.2.4",
@@ -1209,6 +1211,33 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1263,6 +1292,103 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
     },
     "node_modules/@studio-freight/lenis": {
       "version": "1.0.42",
@@ -1611,6 +1737,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1642,7 +1777,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1697,12 +1831,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -2300,6 +2449,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2570,6 +2731,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
@@ -2580,6 +2770,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2638,6 +2845,53 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/call-bind": {
@@ -2762,6 +3016,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3104,6 +3367,18 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3351,6 +3626,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/escalade": {
@@ -3782,6 +4072,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3831,6 +4135,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -4312,6 +4622,35 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4812,6 +5151,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4829,6 +5177,44 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/jerrypick": {
       "version": "1.1.2",
@@ -4901,6 +5287,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5392,7 +5784,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5534,6 +5925,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -6078,6 +6501,86 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.8.tgz",
+      "integrity": "sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^11.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6121,6 +6624,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -6415,6 +6938,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -6574,6 +7112,15 @@
         }
       }
     },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6620,6 +7167,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/three": {
       "version": "0.184.0",
@@ -6799,6 +7351,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6939,7 +7497,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6996,7 +7553,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7073,6 +7629,46 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -7188,6 +7784,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",
+    "@solana/web3.js": "^1.98.4",
     "@studio-freight/lenis": "^1.0.42",
+    "buffer": "^6.0.3",
     "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",

--- a/types/pledge.ts
+++ b/types/pledge.ts
@@ -7,4 +7,12 @@ export type Pledge = {
   minted: boolean;
   ts: number;
   txHash?: string;
+  mintStatus?: "none" | "minted";
+  co2PpmAtMint?: number | null;
+  mintNetwork?: "devnet" | "testnet";
+  walletAddress?: string | null;
+  mintMemo?: string | null;
+  memoProgramId?: string | null;
+  explorerUrl?: string | null;
+  mintedAt?: Date | string | null;
 };


### PR DESCRIPTION
## Summary

Add the first real Solana proof layer to Earth Wrapped.

This introduces optional devnet minting through the browser wallet, stores mint
metadata in Neon, and adds a Neon-backed ledger page for minted pledges. The app continues to use Neon as the serving/query layer while Solana acts as the
verification layer.

## What changed

### Solana mint flow
- added browser-wallet devnet minting using the Solana Memo program
- user wallet signs the transaction in-browser
- transaction is submitted to devnet and confirmed before persistence
- explorer links are generated for verification

### Neon persistence
- minted pledges now persist:
  - `tx_hash`
  - `mint_status`
  - `minted_at`
  - `co2_ppm_at_mint`
  - `mint_network`
  - `wallet_address`
  - `mint_memo`
  - `memo_program_id`
  - `explorer_url`
- added migration SQL for the mint metadata columns
- added uniqueness/indexing support for `tx_hash` and ledger reads
- removed runtime `ALTER TABLE` logic from DB helpers

### Ledger
- added `/ledger`
- ledger reads from Neon, not live Solana RPC crawling
- only minted pledges appear there
- newest entries render first
- each entry links out to Solana Explorer for proof

### Flow integrity
- `Continue without minting` remains intact
- mint failures and Neon persistence failures are surfaced distinctly
- non-minted pledges do not appear in `/ledger`

## Validation

- `npm run lint` passes
- `npm run build` passes
- verified a finalized devnet transaction in Solana Explorer
- verified the memo payload lands on-chain
- verified the architecture does not depend on live chain reads for rendering

