### PR TITLE
fix(next): wrap browser-only rendering in suspense

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/next';
 import { DM_Serif_Display, JetBrains_Mono } from 'next/font/google';
 import { metadata as siteMetadata } from '@/config/site';
@@ -24,8 +24,12 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       lang="en"
       className={`${serif.variable} ${mono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
-      <Analytics />
+      <body className="min-h-full flex flex-col">
+        {children}
+        <Suspense fallback={null}>
+          <Analytics />
+        </Suspense>
+      </body>
     </html>
   );
 }

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { PALETTE, FONTS, ACCENTS } from '@/constants/colors';
 import type { CardCommonProps, Location, Pledge } from '@/types';
 import { VOICE_QUOTES } from '@/constants/quotes';
@@ -146,10 +146,12 @@ export function FinalCard({
       </div>
 
       <div className="ew-final-globe">
-        <FinalGlobe
-          accent={accent}
-          locations={finalGlobeLocations}
-        />
+        <Suspense fallback={null}>
+          <FinalGlobe
+            accent={accent}
+            locations={finalGlobeLocations}
+          />
+        </Suspense>
       </div>
 
       <div


### PR DESCRIPTION
## Summary

Fix the Vercel build failure caused by browser-only rendering during Next 16 prerender.

## Root cause

`@vercel/analytics/next` was mounted directly under `<html>` in
`app/layout.tsx`, outside `<body>` and without a `Suspense` boundary. During
prerender of `/_not-found`, that triggered the browser-render bailout.

## What changed

- moved `<Analytics />` inside `<body>` in `app/layout.tsx`
- wrapped `<Analytics />` in `<Suspense fallback={null}>`
- kept a correct narrow `Suspense` boundary around `<FinalGlobe />` in
  `components/cards/FinalCard.tsx`

## Result

The app now avoids the prerender bailout and builds cleanly on Vercel 

## Validation

- `npm run lint` passes
- `npm run build` passes