### PR TITLE
fix(mobile): repair iPhone Safari story viewport and safe-area layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -505,10 +505,21 @@ body {
 /* ───────────────────────────────────────────────────────────── */
 /* Mobile + Tablet (≤ 1023px) — full-viewport card, no frame    */
 /* ───────────────────────────────────────────────────────────── */
+.ew-stage {
+  width: 100vw;
+  height: 100svh;
+  height: 100dvh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  overflow: hidden;
+}
+
 .ew-stage-bg {
   position: relative;
   width: 100vw;
-  min-height: 100vh;
+  height: 100svh;
+  height: 100dvh;
+  min-height: 100svh;
   min-height: 100dvh;
   padding: 0;
   box-sizing: border-box;
@@ -534,13 +545,23 @@ body {
 .ew-card-frame {
   position: relative;
   width: 100vw;
+  height: 100svh;
   height: 100dvh;
   max-width: 100%;
+  max-height: 100svh;
   max-height: 100dvh;
   border-radius: 0;
   overflow: hidden;
   z-index: 2;
   background: #050608;
+}
+
+@supports (-webkit-touch-callout: none) {
+  .ew-stage,
+  .ew-stage-bg,
+  .ew-card-frame {
+    min-height: -webkit-fill-available;
+  }
 }
 
 .ew-stage-meta,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Suspense, type ReactNode } from 'react';
 import { Analytics } from '@vercel/analytics/next';
+import type { Viewport } from 'next';
 import { DM_Serif_Display, JetBrains_Mono } from 'next/font/google';
 import { metadata as siteMetadata } from '@/config/site';
 import './globals.css';
@@ -17,6 +18,12 @@ const mono = JetBrains_Mono({
 });
 
 export const metadata = siteMetadata;
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+};
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -157,7 +157,9 @@ export function FinalCard({
       <div
         style={{
           position: 'absolute',
-          bottom: 168,
+          bottom: isDesktop
+            ? 168
+            : 'calc(env(safe-area-inset-bottom, 0px) + 168px)',
           left: 0,
           right: 0,
           zIndex: 15,
@@ -208,7 +210,9 @@ export function FinalCard({
       <div
         style={{
           position: 'absolute',
-          bottom: 56,
+          bottom: isDesktop
+            ? 56
+            : 'calc(env(safe-area-inset-bottom, 0px) + 56px)',
           left: 32,
           right: 32,
           zIndex: 15,

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -108,9 +108,11 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              top: 180,
-              left: 32,
-              right: 32,
+              top: isDesktop
+                ? 180
+                : "calc(env(safe-area-inset-top, 0px) + clamp(96px, 16dvh, 132px))",
+              left: isDesktop ? 32 : 24,
+              right: isDesktop ? 32 : 24,
               textAlign: "center",
               zIndex: 10,
             }}
@@ -118,11 +120,11 @@ export function PledgeCard({
             <div
               style={{
                 fontFamily: FONTS.MONO,
-                fontSize: 10,
-                letterSpacing: "0.3em",
+                fontSize: isDesktop ? 10 : 9.5,
+                letterSpacing: isDesktop ? "0.3em" : "0.26em",
                 textTransform: "uppercase",
                 color: PALETTE.ASH_DIM,
-                marginBottom: 16,
+                marginBottom: isDesktop ? 16 : 12,
               }}
             >
               Earth requests
@@ -130,7 +132,7 @@ export function PledgeCard({
             <div
               style={{
                 fontFamily: FONTS.SERIF,
-                fontSize: 34,
+                fontSize: isDesktop ? 34 : 31,
                 lineHeight: 1.1,
                 fontStyle: "italic",
                 color: PALETTE.ASH,
@@ -147,7 +149,9 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              top: 340,
+              top: isDesktop
+                ? 340
+                : "calc(env(safe-area-inset-top, 0px) + clamp(196px, 31dvh, 260px))",
               left: isDesktop ? "50%" : 24,
               right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",
@@ -157,7 +161,14 @@ export function PledgeCard({
           >
             {!writing && (
               <>
-                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div
+                  style={{
+                    display: isDesktop ? "flex" : "grid",
+                    flexDirection: "column",
+                    gridTemplateColumns: isDesktop ? undefined : "1fr 1fr",
+                    gap: isDesktop ? 8 : 7,
+                  }}
+                >
                   {PRESETS.map((p) => (
                     <button
                       key={p.id}
@@ -169,16 +180,17 @@ export function PledgeCard({
                         all: "unset",
                         cursor: "pointer",
                         textAlign: "center",
-                        padding: "13px 16px",
-                        borderRadius: 12,
+                        padding: isDesktop ? "13px 16px" : "10px 8px",
+                        borderRadius: isDesktop ? 12 : 10,
                         background:
                           choice === p.id
                             ? `${accent.hex}22`
                             : "rgba(230,214,190,0.04)",
                         border: `1px solid ${choice === p.id ? accent.hex : "rgba(230,214,190,0.14)"}`,
                         fontFamily: FONTS.MONO,
-                        fontSize: 11.5,
-                        letterSpacing: "0.14em",
+                        fontSize: isDesktop ? 11.5 : 9.2,
+                        lineHeight: 1.25,
+                        letterSpacing: isDesktop ? "0.14em" : "0.1em",
                         textTransform: "uppercase",
                         color: choice === p.id ? PALETTE.ASH : PALETTE.ASH_DIM,
                         fontWeight: 500,
@@ -203,12 +215,12 @@ export function PledgeCard({
                     width: "100%",
                     boxSizing: "border-box",
                     marginTop: 8,
-                    padding: "13px 16px",
-                    borderRadius: 12,
+                    padding: isDesktop ? "13px 16px" : "10px 12px",
+                    borderRadius: isDesktop ? 12 : 10,
                     border: "1px dashed rgba(230,214,190,0.2)",
                     fontFamily: FONTS.MONO,
-                    fontSize: 11.5,
-                    letterSpacing: "0.14em",
+                    fontSize: isDesktop ? 11.5 : 9.6,
+                    letterSpacing: isDesktop ? "0.14em" : "0.12em",
                     textTransform: "uppercase",
                     color: PALETTE.ASH_DIMMER,
                     fontWeight: 500,
@@ -231,14 +243,14 @@ export function PledgeCard({
                   style={{
                     width: "100%",
                     boxSizing: "border-box",
-                    height: 34,
+                    height: isDesktop ? 34 : 30,
                     padding: "0 0 3px",
                     borderRadius: 0,
                     background: "transparent",
                     border: 0,
                     borderBottom: `1px solid ${PALETTE.ASH_DIM}`,
                     fontFamily: FONTS.SERIF,
-                    fontSize: 22,
+                    fontSize: isDesktop ? 22 : 20,
                     lineHeight: 1,
                     color: PALETTE.ASH,
                     outline: "none",
@@ -250,8 +262,8 @@ export function PledgeCard({
                     marginTop: 6,
                     textAlign: "right",
                     fontFamily: FONTS.MONO,
-                    fontSize: 9,
-                    letterSpacing: "0.2em",
+                    fontSize: isDesktop ? 9 : 8,
+                    letterSpacing: isDesktop ? "0.2em" : "0.18em",
                     color: PALETTE.ASH_DIMMER,
                   }}
                 >
@@ -261,8 +273,8 @@ export function PledgeCard({
                   style={{
                     display: "flex",
                     flexDirection: "column",
-                    gap: 10,
-                    marginTop: 16,
+                    gap: isDesktop ? 10 : 8,
+                    marginTop: isDesktop ? 16 : 12,
                     padding: "0 4px",
                   }}
                 >
@@ -272,7 +284,7 @@ export function PledgeCard({
                       alignItems: "baseline",
                       gap: 10,
                       fontFamily: FONTS.SERIF,
-                      fontSize: 18,
+                      fontSize: isDesktop ? 18 : 16,
                       fontStyle: "italic",
                       color: PALETTE.ASH,
                     }}
@@ -291,7 +303,7 @@ export function PledgeCard({
                         padding: "0 0 4px",
                         borderBottom: "1px solid rgba(230,214,190,0.45)",
                         fontFamily: FONTS.SERIF,
-                        fontSize: 19,
+                        fontSize: isDesktop ? 19 : 17,
                         lineHeight: 1.2,
                         fontStyle: "italic",
                         color: PALETTE.ASH,
@@ -304,7 +316,7 @@ export function PledgeCard({
                       alignItems: "baseline",
                       gap: 10,
                       fontFamily: FONTS.SERIF,
-                      fontSize: 16,
+                      fontSize: isDesktop ? 16 : 15,
                       fontStyle: "italic",
                       color: PALETTE.ASH_DIM,
                     }}
@@ -323,7 +335,7 @@ export function PledgeCard({
                         padding: "0 0 4px",
                         borderBottom: "1px solid rgba(230,214,190,0.32)",
                         fontFamily: FONTS.SERIF,
-                        fontSize: 17,
+                        fontSize: isDesktop ? 17 : 16,
                         lineHeight: 1.2,
                         fontStyle: "italic",
                         color: PALETTE.ASH,
@@ -342,11 +354,11 @@ export function PledgeCard({
                     cursor: "pointer",
                     textAlign: "center",
                     display: "block",
-                    margin: "8px auto 0",
-                    padding: "6px 12px",
+                    margin: isDesktop ? "8px auto 0" : "6px auto 0",
+                    padding: isDesktop ? "6px 12px" : "5px 10px",
                     fontFamily: FONTS.MONO,
-                    fontSize: 9,
-                    letterSpacing: "0.22em",
+                    fontSize: isDesktop ? 9 : 8,
+                    letterSpacing: isDesktop ? "0.22em" : "0.18em",
                     textTransform: "uppercase",
                     color: PALETTE.ASH_DIMMER,
                   }}
@@ -360,9 +372,11 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              bottom: 80,
-              left: isDesktop ? "50%" : 32,
-              right: isDesktop ? "auto" : 32,
+              bottom: isDesktop
+                ? 80
+                : "calc(env(safe-area-inset-bottom, 0px) + 34px)",
+              left: isDesktop ? "50%" : 24,
+              right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",
               transform: isDesktop ? "translateX(-50%)" : undefined,
               zIndex: 15,
@@ -387,12 +401,12 @@ export function PledgeCard({
                 display: "block",
                 width: "100%",
                 boxSizing: "border-box",
-                marginTop: 8,
-                padding: "10px 12px",
+                marginTop: isDesktop ? 8 : 6,
+                padding: isDesktop ? "10px 12px" : "8px 10px",
                 textAlign: "center",
                 fontFamily: FONTS.MONO,
-                fontSize: 10.5,
-                letterSpacing: "0.22em",
+                fontSize: isDesktop ? 10.5 : 9.2,
+                letterSpacing: isDesktop ? "0.22em" : "0.18em",
                 textTransform: "uppercase",
                 color: minting ? PALETTE.ASH_DIMMER : PALETTE.ASH_DIM,
                 fontWeight: 600,
@@ -404,11 +418,11 @@ export function PledgeCard({
             </button>
             <div
               style={{
-                marginTop: 6,
+                marginTop: isDesktop ? 6 : 4,
                 textAlign: "center",
                 fontFamily: FONTS.MONO,
-                fontSize: 8,
-                letterSpacing: "0.24em",
+                fontSize: isDesktop ? 8 : 7.2,
+                letterSpacing: isDesktop ? "0.24em" : "0.18em",
                 textTransform: "uppercase",
                 color: PALETTE.ASH_DIMMER,
               }}

--- a/components/ui/CardChrome.tsx
+++ b/components/ui/CardChrome.tsx
@@ -24,7 +24,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: 28,
+          bottom: "calc(env(safe-area-inset-bottom, 0px) + 28px)",
           left: 0,
           right: 0,
           zIndex: 25,
@@ -114,7 +114,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: 8,
+          bottom: "calc(env(safe-area-inset-bottom, 0px) + 8px)",
           left: 0,
           right: 0,
           zIndex: 25,

--- a/components/ui/CardMeta.tsx
+++ b/components/ui/CardMeta.tsx
@@ -20,7 +20,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
         className="ew-card-meta"
         style={{
           position: 'absolute',
-          top: isDesktop ? 48 : 36,
+          top: isDesktop ? 48 : 'calc(env(safe-area-inset-top, 0px) + 30px)',
           left: isDesktop ? '4vw' : 24,
           right: isDesktop ? '4vw' : 24,
           zIndex: 20,
@@ -47,7 +47,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
           className="ew-card-chapter"
           style={{
             position: 'absolute',
-            top: isDesktop ? 48 : 74,
+            top: isDesktop ? 48 : 'calc(env(safe-area-inset-top, 0px) + 68px)',
             left: isDesktop ? '50%' : 24,
             transform: isDesktop ? 'translateX(-50%)' : undefined,
             width: isDesktop ? 'min(52vw, 620px)' : undefined,

--- a/components/ui/MintButton.tsx
+++ b/components/ui/MintButton.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { PALETTE, FONTS } from "@/constants/colors";
+import { useMediaMin } from "@/hooks/useBreakpoint";
 import type { Accent } from "@/types";
 
 type MintButtonProps = {
@@ -12,6 +13,7 @@ type MintButtonProps = {
 };
 
 export function MintButton({ accent, disabled, minting, onClick }: MintButtonProps) {
+  const isDesktop = useMediaMin(1024);
   const active = !disabled && !minting;
   return (
     <motion.button
@@ -28,13 +30,13 @@ export function MintButton({ accent, disabled, minting, onClick }: MintButtonPro
         display: "block",
         width: "100%",
         boxSizing: "border-box",
-        padding: "16px",
+        padding: isDesktop ? "16px" : "12px 14px",
         borderRadius: 12,
         background: active ? `${accent.hex}40` : "rgba(230,214,190,0.04)",
         border: `1px solid ${active ? accent.hex : "rgba(230,214,190,0.14)"}`,
         fontFamily: FONTS.MONO,
-        fontSize: 11,
-        letterSpacing: "0.28em",
+        fontSize: isDesktop ? 11 : 10,
+        letterSpacing: isDesktop ? "0.28em" : "0.22em",
         textTransform: "uppercase",
         color: active ? PALETTE.ASH : PALETTE.ASH_DIMMER,
         fontWeight: 500,


### PR DESCRIPTION
## Summary

Fix the broken iPhone Safari mobile layout in the Earth Wrapped story flow.

## What changed

### Fullscreen story shell
- updated the mobile story/stage/card wrapper chain to use scoped `svh`/`dvh`
  sizing instead of relying on a partial viewport-height chain
- fixed the black bar issue caused by the outer wrappers not owning the full
  dynamic viewport height

### Safe-area handling
- added `viewportFit: 'cover'` in `app/layout.tsx`
- added safe-area-aware top offsets for mobile metadata
- added safe-area-aware bottom offsets for story chrome/footer controls
- updated the final card’s lower text blocks to clear the iPhone home indicator

### Pledge card mobile layout
- moved the mobile header and control cluster into viewport/safe-area-aware positions
- tightened mobile button padding, typography, and helper spacing
- changed preset pledge buttons to a 2-column mobile grid
- kept the desktop pledge layout unchanged

## Validation

- `npm run lint` passes
- `npm run build` passes
