### PR TITLE
fix(mobile): use visualViewport sizing for iPhone Safari story shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -506,21 +506,21 @@ body {
 /* Mobile + Tablet (≤ 1023px) — full-viewport card, no frame    */
 /* ───────────────────────────────────────────────────────────── */
 .ew-stage {
+  --ew-story-viewport-height: 100svh;
+  --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 20px);
+  --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);
   width: 100vw;
-  height: 100svh;
-  height: 100dvh;
-  min-height: 100svh;
-  min-height: 100dvh;
+  height: var(--ew-story-viewport-height);
+  min-height: var(--ew-story-viewport-height);
   overflow: hidden;
+  background: #050608;
 }
 
 .ew-stage-bg {
   position: relative;
   width: 100vw;
-  height: 100svh;
-  height: 100dvh;
-  min-height: 100svh;
-  min-height: 100dvh;
+  height: var(--ew-story-viewport-height);
+  min-height: var(--ew-story-viewport-height);
   padding: 0;
   box-sizing: border-box;
   background-color: #0a0e1a;
@@ -545,23 +545,14 @@ body {
 .ew-card-frame {
   position: relative;
   width: 100vw;
-  height: 100svh;
-  height: 100dvh;
+  height: var(--ew-story-viewport-height);
+  min-height: var(--ew-story-viewport-height);
   max-width: 100%;
-  max-height: 100svh;
-  max-height: 100dvh;
+  max-height: var(--ew-story-viewport-height);
   border-radius: 0;
   overflow: hidden;
   z-index: 2;
   background: #050608;
-}
-
-@supports (-webkit-touch-callout: none) {
-  .ew-stage,
-  .ew-stage-bg,
-  .ew-card-frame {
-    min-height: -webkit-fill-available;
-  }
 }
 
 .ew-stage-meta,

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ACTIVE_STORAGE_KEY,
@@ -27,6 +27,11 @@ import { RenewablesCard } from "@/components/cards/RenewablesCard";
 import { FinalCard } from "@/components/cards/FinalCard";
 
 type MobileStoryProps = { tweaks: Tweaks };
+type StoryViewportStyle = CSSProperties & Record<"--ew-story-viewport-height", string>;
+
+const DEFAULT_STORY_VIEWPORT_STYLE: StoryViewportStyle = {
+  "--ew-story-viewport-height": "100svh",
+};
 
 function clampIndex(n: number): number {
   if (!Number.isFinite(n)) return 0;
@@ -39,6 +44,46 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   const [userLocation, setUserLocation] = useState<Location | null>(null);
   const [userPledge, setUserPledge] = useState<Pledge | null>(null);
   const [restoredActive, setRestoredActive] = useState(false);
+  const [viewportStyle, setViewportStyle] = useState<StoryViewportStyle>(
+    DEFAULT_STORY_VIEWPORT_STYLE,
+  );
+
+  useEffect(() => {
+    let frame = 0;
+
+    const updateViewportHeight = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        const height = Math.round(
+          window.visualViewport?.height ?? window.innerHeight,
+        );
+        if (!Number.isFinite(height) || height <= 0) return;
+
+        const nextStyle: StoryViewportStyle = {
+          "--ew-story-viewport-height": `${height}px`,
+        };
+        setViewportStyle((current) =>
+          current["--ew-story-viewport-height"] === nextStyle["--ew-story-viewport-height"]
+            ? current
+            : nextStyle,
+        );
+      });
+    };
+
+    updateViewportHeight();
+    window.visualViewport?.addEventListener("resize", updateViewportHeight);
+    window.visualViewport?.addEventListener("scroll", updateViewportHeight);
+    window.addEventListener("resize", updateViewportHeight);
+    window.addEventListener("orientationchange", updateViewportHeight);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.visualViewport?.removeEventListener("resize", updateViewportHeight);
+      window.visualViewport?.removeEventListener("scroll", updateViewportHeight);
+      window.removeEventListener("resize", updateViewportHeight);
+      window.removeEventListener("orientationchange", updateViewportHeight);
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -109,7 +154,12 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   };
 
   return (
-    <SwipeContainer onNext={next} onPrev={prev} className="ew-stage">
+    <SwipeContainer
+      onNext={next}
+      onPrev={prev}
+      className="ew-stage"
+      style={viewportStyle}
+    >
       <motion.div
         className="ew-stage-bg"
         initial={false}

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -159,7 +159,7 @@ export function FinalCard({
           position: 'absolute',
           bottom: isDesktop
             ? 168
-            : 'calc(env(safe-area-inset-bottom, 0px) + 168px)',
+            : 'calc(var(--ew-story-bottom-safe, 0px) + 168px)',
           left: 0,
           right: 0,
           zIndex: 15,
@@ -212,7 +212,7 @@ export function FinalCard({
           position: 'absolute',
           bottom: isDesktop
             ? 56
-            : 'calc(env(safe-area-inset-bottom, 0px) + 56px)',
+            : 'calc(var(--ew-story-bottom-safe, 0px) + 56px)',
           left: 32,
           right: 32,
           zIndex: 15,

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -110,7 +110,7 @@ export function PledgeCard({
               position: "absolute",
               top: isDesktop
                 ? 180
-                : "calc(env(safe-area-inset-top, 0px) + clamp(96px, 16dvh, 132px))",
+                : "calc(var(--ew-story-top-safe, 20px) + clamp(68px, 12svh, 104px))",
               left: isDesktop ? 32 : 24,
               right: isDesktop ? 32 : 24,
               textAlign: "center",
@@ -151,7 +151,7 @@ export function PledgeCard({
               position: "absolute",
               top: isDesktop
                 ? 340
-                : "calc(env(safe-area-inset-top, 0px) + clamp(196px, 31dvh, 260px))",
+                : "calc(var(--ew-story-top-safe, 20px) + clamp(166px, 27svh, 224px))",
               left: isDesktop ? "50%" : 24,
               right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",
@@ -374,7 +374,7 @@ export function PledgeCard({
               position: "absolute",
               bottom: isDesktop
                 ? 80
-                : "calc(env(safe-area-inset-bottom, 0px) + 34px)",
+                : "calc(var(--ew-story-bottom-safe, 0px) + 26px)",
               left: isDesktop ? "50%" : 24,
               right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",

--- a/components/ui/CardChrome.tsx
+++ b/components/ui/CardChrome.tsx
@@ -24,7 +24,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: "calc(env(safe-area-inset-bottom, 0px) + 28px)",
+          bottom: "calc(var(--ew-story-bottom-safe, 0px) + 28px)",
           left: 0,
           right: 0,
           zIndex: 25,
@@ -114,7 +114,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: "calc(env(safe-area-inset-bottom, 0px) + 8px)",
+          bottom: "calc(var(--ew-story-bottom-safe, 0px) + 8px)",
           left: 0,
           right: 0,
           zIndex: 25,

--- a/components/ui/CardMeta.tsx
+++ b/components/ui/CardMeta.tsx
@@ -20,7 +20,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
         className="ew-card-meta"
         style={{
           position: 'absolute',
-          top: isDesktop ? 48 : 'calc(env(safe-area-inset-top, 0px) + 30px)',
+          top: isDesktop ? 48 : 'calc(var(--ew-story-top-safe, 20px) + 28px)',
           left: isDesktop ? '4vw' : 24,
           right: isDesktop ? '4vw' : 24,
           zIndex: 20,
@@ -47,7 +47,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
           className="ew-card-chapter"
           style={{
             position: 'absolute',
-            top: isDesktop ? 48 : 'calc(env(safe-area-inset-top, 0px) + 68px)',
+            top: isDesktop ? 48 : 'calc(var(--ew-story-top-safe, 20px) + 66px)',
             left: isDesktop ? '50%' : 24,
             transform: isDesktop ? 'translateX(-50%)' : undefined,
             width: isDesktop ? 'min(52vw, 620px)' : undefined,

--- a/components/ui/SwipeContainer.tsx
+++ b/components/ui/SwipeContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useSwipe } from "@/hooks/useSwipe";
 
 type SwipeContainerProps = {
@@ -8,12 +8,13 @@ type SwipeContainerProps = {
   onPrev: () => void;
   children: ReactNode;
   className?: string;
+  style?: CSSProperties;
 };
 
-export function SwipeContainer({ onNext, onPrev, children, className }: SwipeContainerProps) {
+export function SwipeContainer({ onNext, onPrev, children, className, style }: SwipeContainerProps) {
   const handlers = useSwipe({ onNext, onPrev });
   return (
-    <div className={className} {...handlers} style={{ touchAction: "pan-y" }}>
+    <div className={className} {...handlers} style={{ ...style, touchAction: "pan-y" }}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Fix the actual iPhone Safari mobile story bug by sizing the story shell from the real visible viewport instead of relying on Safari viewport units alone.

## What changed

### Measured viewport shell
- `MobileStory.tsx` now measures `window.visualViewport.height`
- writes that value to `--ew-story-viewport-height`
- updates on:
  - `visualViewport.resize`
  - `visualViewport.scroll`
  - `resize`
  - `orientationchange`

### Story wrappers
- `.ew-stage`, `.ew-stage-bg`, and `.ew-card-frame` now size from
  `var(--ew-story-viewport-height)`
- removed the `-webkit-fill-available` fallback that could force the frame
  taller than the visible Safari viewport

### Safe-area alignment
- `CardMeta.tsx` now uses the story-level safe top variable
- `CardChrome.tsx` now uses the story-level safe bottom variable
- `FinalCard.tsx` now uses the same story safe-bottom handling for lower text

### Pledge card mobile layout
- pulled the mobile pledge content back into the visible canvas
- switched vertical layout to stable `svh`-based clamps where appropriate
- anchored the bottom mint cluster to the measured story frame instead of the
  hidden Safari toolbar area

## Files changed

- `components/MobileStory.tsx`
- `app/globals.css`
- `components/ui/SwipeContainer.tsx`
- `components/ui/CardMeta.tsx`
- `components/ui/CardChrome.tsx`
- `components/cards/PledgeCard.tsx`
- `components/cards/FinalCard.tsx`

## Validation

- `npm run lint` passes
- `npm run build` passes
