### PR TITLE
fix(mobile): lock iPhone Safari story to the visual viewport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -505,22 +505,44 @@ body {
 /* ───────────────────────────────────────────────────────────── */
 /* Mobile + Tablet (≤ 1023px) — full-viewport card, no frame    */
 /* ───────────────────────────────────────────────────────────── */
+html.ew-story-locked,
+body.ew-story-locked {
+  overscroll-behavior: none;
+}
+
+body.ew-story-locked {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  overflow: hidden;
+  background: #0a0e1a;
+}
+
 .ew-stage {
   --ew-story-viewport-height: 100svh;
-  --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 20px);
-  --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);
-  width: 100vw;
+  --ew-story-viewport-width: 100%;
+  --ew-story-bottom-reserve: 0px;
+  --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 24px);
+  --ew-story-bottom-safe: max(
+    env(safe-area-inset-bottom, 0px),
+    var(--ew-story-bottom-reserve)
+  );
+  position: fixed;
+  inset: 0;
+  width: var(--ew-story-viewport-width);
+  max-width: 100%;
   height: var(--ew-story-viewport-height);
-  min-height: var(--ew-story-viewport-height);
+  min-height: 0;
   overflow: hidden;
-  background: #050608;
+  background: #0a0e1a;
+  overscroll-behavior: none;
 }
 
 .ew-stage-bg {
   position: relative;
-  width: 100vw;
-  height: var(--ew-story-viewport-height);
-  min-height: var(--ew-story-viewport-height);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
   padding: 0;
   box-sizing: border-box;
   background-color: #0a0e1a;
@@ -544,15 +566,15 @@ body {
 
 .ew-card-frame {
   position: relative;
-  width: 100vw;
-  height: var(--ew-story-viewport-height);
-  min-height: var(--ew-story-viewport-height);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
   max-width: 100%;
-  max-height: var(--ew-story-viewport-height);
+  max-height: 100%;
   border-radius: 0;
   overflow: hidden;
   z-index: 2;
-  background: #050608;
+  background: #0a0e1a;
 }
 
 .ew-stage-meta,

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -27,15 +27,30 @@ import { RenewablesCard } from "@/components/cards/RenewablesCard";
 import { FinalCard } from "@/components/cards/FinalCard";
 
 type MobileStoryProps = { tweaks: Tweaks };
-type StoryViewportStyle = CSSProperties & Record<"--ew-story-viewport-height", string>;
+type StoryViewportVar =
+  | "--ew-story-viewport-height"
+  | "--ew-story-viewport-width"
+  | "--ew-story-bottom-reserve";
+type StoryViewportStyle = CSSProperties & Record<StoryViewportVar, string>;
 
 const DEFAULT_STORY_VIEWPORT_STYLE: StoryViewportStyle = {
   "--ew-story-viewport-height": "100svh",
+  "--ew-story-viewport-width": "100%",
+  "--ew-story-bottom-reserve": "0px",
 };
 
 function clampIndex(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.min(Math.max(Math.trunc(n), 0), TOTAL_CARDS - 1);
+}
+
+function isIOSWebKit(): boolean {
+  const platform = window.navigator.platform;
+  const maxTouchPoints = window.navigator.maxTouchPoints;
+  return (
+    /iP(hone|od|ad)/.test(platform) ||
+    (platform === "MacIntel" && maxTouchPoints > 1)
+  );
 }
 
 export function MobileStory({ tweaks }: MobileStoryProps) {
@@ -49,39 +64,77 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   );
 
   useEffect(() => {
+    document.documentElement.classList.add("ew-story-locked");
+    document.body.classList.add("ew-story-locked");
+
+    return () => {
+      document.documentElement.classList.remove("ew-story-locked");
+      document.body.classList.remove("ew-story-locked");
+    };
+  }, []);
+
+  useEffect(() => {
+    const isIOS = isIOSWebKit();
     let frame = 0;
 
-    const updateViewportHeight = () => {
+    const updateViewport = () => {
       window.cancelAnimationFrame(frame);
       frame = window.requestAnimationFrame(() => {
-        const height = Math.round(
-          window.visualViewport?.height ?? window.innerHeight,
-        );
-        if (!Number.isFinite(height) || height <= 0) return;
+        const visualViewport = window.visualViewport;
+        const height = Math.round(visualViewport?.height ?? window.innerHeight);
+        const width = Math.round(visualViewport?.width ?? window.innerWidth);
+        if (
+          !Number.isFinite(height) ||
+          !Number.isFinite(width) ||
+          height <= 0 ||
+          width <= 0
+        ) {
+          return;
+        }
+
+        const bottomOcclusion = visualViewport
+          ? Math.max(
+              0,
+              Math.round(
+                window.innerHeight -
+                  visualViewport.height -
+                  visualViewport.offsetTop,
+              ),
+            )
+          : 0;
+        const safariToolbarReserve =
+          isIOS && width < 768 ? Math.max(bottomOcclusion, 92) : bottomOcclusion;
 
         const nextStyle: StoryViewportStyle = {
           "--ew-story-viewport-height": `${height}px`,
+          "--ew-story-viewport-width": `${width}px`,
+          "--ew-story-bottom-reserve": `${safariToolbarReserve}px`,
         };
         setViewportStyle((current) =>
-          current["--ew-story-viewport-height"] === nextStyle["--ew-story-viewport-height"]
+          current["--ew-story-viewport-height"] ===
+            nextStyle["--ew-story-viewport-height"] &&
+          current["--ew-story-viewport-width"] ===
+            nextStyle["--ew-story-viewport-width"] &&
+          current["--ew-story-bottom-reserve"] ===
+            nextStyle["--ew-story-bottom-reserve"]
             ? current
             : nextStyle,
         );
       });
     };
 
-    updateViewportHeight();
-    window.visualViewport?.addEventListener("resize", updateViewportHeight);
-    window.visualViewport?.addEventListener("scroll", updateViewportHeight);
-    window.addEventListener("resize", updateViewportHeight);
-    window.addEventListener("orientationchange", updateViewportHeight);
+    updateViewport();
+    window.visualViewport?.addEventListener("resize", updateViewport);
+    window.visualViewport?.addEventListener("scroll", updateViewport);
+    window.addEventListener("resize", updateViewport);
+    window.addEventListener("orientationchange", updateViewport);
 
     return () => {
       window.cancelAnimationFrame(frame);
-      window.visualViewport?.removeEventListener("resize", updateViewportHeight);
-      window.visualViewport?.removeEventListener("scroll", updateViewportHeight);
-      window.removeEventListener("resize", updateViewportHeight);
-      window.removeEventListener("orientationchange", updateViewportHeight);
+      window.visualViewport?.removeEventListener("resize", updateViewport);
+      window.visualViewport?.removeEventListener("scroll", updateViewport);
+      window.removeEventListener("resize", updateViewport);
+      window.removeEventListener("orientationchange", updateViewport);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Fix the iPhone Safari mobile story layout by moving away from normal webpage
viewport assumptions and anchoring the story shell to the real visual viewport.

## Root cause

This was not a simple `100vh` issue.

The mobile story was still behaving like a regular webpage:
- `100vw` caused horizontal overflow on iPhone Safari
- `100svh` plus safe-area handling still did not account for Safari’s bottom browser toolbar
- the story shell was not locked to a native-style fixed viewport
- the page/background could show through at the bottom
- `env(safe-area-inset-bottom)` only covers the home indicator, not Safari’s browser chrome

## What changed

- `MobileStory.tsx`
  - now measures `visualViewport.width` and `visualViewport.height`
  - locks `html`/`body` scrolling only while the mobile story is mounted
  - adds a scoped iPhone Safari bottom-toolbar reserve so controls stay above browser chrome

- `app/globals.css`
  - mobile story stage is now `position: fixed; inset: 0`
  - removed `100vw` sizing from the story shell/frame
  - uses the measured viewport dimensions instead
  - changed the fallback exposed background from near-black to the story navy tone

## Validation

- `npm run lint` passes
- `npm run build` passes
