### PR TITLE
refactor(mobile): simplify the story shell and centralize layout safety

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -511,28 +511,40 @@ body.ew-story-locked {
 }
 
 body.ew-story-locked {
-  position: fixed;
-  inset: 0;
   width: 100%;
+  min-height: 100%;
   overflow: hidden;
   background: #0a0e1a;
 }
 
 .ew-stage {
-  --ew-story-viewport-height: 100svh;
-  --ew-story-viewport-width: 100%;
-  --ew-story-bottom-reserve: 0px;
   --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 24px);
-  --ew-story-bottom-safe: max(
-    env(safe-area-inset-bottom, 0px),
-    var(--ew-story-bottom-reserve)
+  --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);
+  --ew-story-meta-top: calc(var(--ew-story-top-safe) + 28px);
+  --ew-story-chapter-top: calc(var(--ew-story-top-safe) + 66px);
+  --ew-story-nav-bottom: calc(var(--ew-story-bottom-safe) + 18px);
+  --ew-story-footer-bottom: calc(var(--ew-story-bottom-safe) + 4px);
+  --ew-story-quote-bottom: calc(var(--ew-story-nav-bottom) + 58px);
+  --ew-story-stat-label-bottom: 180px;
+  --ew-story-horizon-bottom: 158px;
+  --ew-story-location-actions-bottom: calc(var(--ew-story-nav-bottom) + 58px);
+  --ew-story-pledge-title-top: calc(
+    var(--ew-story-top-safe) + clamp(68px, 12svh, 104px)
   );
+  --ew-story-pledge-form-top: calc(
+    var(--ew-story-top-safe) + clamp(166px, 27svh, 224px)
+  );
+  --ew-story-action-bottom: calc(var(--ew-story-bottom-safe) + 24px);
+  --ew-story-final-count-bottom: calc(var(--ew-story-bottom-safe) + 168px);
+  --ew-story-final-signoff-bottom: calc(var(--ew-story-bottom-safe) + 56px);
   position: fixed;
   inset: 0;
-  width: var(--ew-story-viewport-width);
+  width: 100vw;
   max-width: 100%;
-  height: var(--ew-story-viewport-height);
-  min-height: 0;
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
+  min-height: 100svh;
   overflow: hidden;
   background: #0a0e1a;
   overscroll-behavior: none;

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ACTIVE_STORAGE_KEY,
@@ -27,30 +27,10 @@ import { RenewablesCard } from "@/components/cards/RenewablesCard";
 import { FinalCard } from "@/components/cards/FinalCard";
 
 type MobileStoryProps = { tweaks: Tweaks };
-type StoryViewportVar =
-  | "--ew-story-viewport-height"
-  | "--ew-story-viewport-width"
-  | "--ew-story-bottom-reserve";
-type StoryViewportStyle = CSSProperties & Record<StoryViewportVar, string>;
-
-const DEFAULT_STORY_VIEWPORT_STYLE: StoryViewportStyle = {
-  "--ew-story-viewport-height": "100svh",
-  "--ew-story-viewport-width": "100%",
-  "--ew-story-bottom-reserve": "0px",
-};
 
 function clampIndex(n: number): number {
   if (!Number.isFinite(n)) return 0;
   return Math.min(Math.max(Math.trunc(n), 0), TOTAL_CARDS - 1);
-}
-
-function isIOSWebKit(): boolean {
-  const platform = window.navigator.platform;
-  const maxTouchPoints = window.navigator.maxTouchPoints;
-  return (
-    /iP(hone|od|ad)/.test(platform) ||
-    (platform === "MacIntel" && maxTouchPoints > 1)
-  );
 }
 
 export function MobileStory({ tweaks }: MobileStoryProps) {
@@ -59,9 +39,6 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   const [userLocation, setUserLocation] = useState<Location | null>(null);
   const [userPledge, setUserPledge] = useState<Pledge | null>(null);
   const [restoredActive, setRestoredActive] = useState(false);
-  const [viewportStyle, setViewportStyle] = useState<StoryViewportStyle>(
-    DEFAULT_STORY_VIEWPORT_STYLE,
-  );
 
   useEffect(() => {
     document.documentElement.classList.add("ew-story-locked");
@@ -70,71 +47,6 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
     return () => {
       document.documentElement.classList.remove("ew-story-locked");
       document.body.classList.remove("ew-story-locked");
-    };
-  }, []);
-
-  useEffect(() => {
-    const isIOS = isIOSWebKit();
-    let frame = 0;
-
-    const updateViewport = () => {
-      window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(() => {
-        const visualViewport = window.visualViewport;
-        const height = Math.round(visualViewport?.height ?? window.innerHeight);
-        const width = Math.round(visualViewport?.width ?? window.innerWidth);
-        if (
-          !Number.isFinite(height) ||
-          !Number.isFinite(width) ||
-          height <= 0 ||
-          width <= 0
-        ) {
-          return;
-        }
-
-        const bottomOcclusion = visualViewport
-          ? Math.max(
-              0,
-              Math.round(
-                window.innerHeight -
-                  visualViewport.height -
-                  visualViewport.offsetTop,
-              ),
-            )
-          : 0;
-        const safariToolbarReserve =
-          isIOS && width < 768 ? Math.max(bottomOcclusion, 92) : bottomOcclusion;
-
-        const nextStyle: StoryViewportStyle = {
-          "--ew-story-viewport-height": `${height}px`,
-          "--ew-story-viewport-width": `${width}px`,
-          "--ew-story-bottom-reserve": `${safariToolbarReserve}px`,
-        };
-        setViewportStyle((current) =>
-          current["--ew-story-viewport-height"] ===
-            nextStyle["--ew-story-viewport-height"] &&
-          current["--ew-story-viewport-width"] ===
-            nextStyle["--ew-story-viewport-width"] &&
-          current["--ew-story-bottom-reserve"] ===
-            nextStyle["--ew-story-bottom-reserve"]
-            ? current
-            : nextStyle,
-        );
-      });
-    };
-
-    updateViewport();
-    window.visualViewport?.addEventListener("resize", updateViewport);
-    window.visualViewport?.addEventListener("scroll", updateViewport);
-    window.addEventListener("resize", updateViewport);
-    window.addEventListener("orientationchange", updateViewport);
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-      window.visualViewport?.removeEventListener("resize", updateViewport);
-      window.visualViewport?.removeEventListener("scroll", updateViewport);
-      window.removeEventListener("resize", updateViewport);
-      window.removeEventListener("orientationchange", updateViewport);
     };
   }, []);
 
@@ -207,12 +119,7 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   };
 
   return (
-    <SwipeContainer
-      onNext={next}
-      onPrev={prev}
-      className="ew-stage"
-      style={viewportStyle}
-    >
+    <SwipeContainer onNext={next} onPrev={prev} className="ew-stage">
       <motion.div
         className="ew-stage-bg"
         initial={false}

--- a/components/cards/CO2Card.tsx
+++ b/components/cards/CO2Card.tsx
@@ -124,7 +124,7 @@ export function CO2Card({
 
       <StatLabel>Above preindustrial</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
       <StatSourceMeta
         rows={['SRC: NOAA GML']}
         dim={['MAUNA LOA', 'PRELIMINARY']}

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -157,9 +157,7 @@ export function FinalCard({
       <div
         style={{
           position: 'absolute',
-          bottom: isDesktop
-            ? 168
-            : 'calc(var(--ew-story-bottom-safe, 0px) + 168px)',
+          bottom: isDesktop ? 168 : 'var(--ew-story-final-count-bottom, 168px)',
           left: 0,
           right: 0,
           zIndex: 15,
@@ -210,9 +208,7 @@ export function FinalCard({
       <div
         style={{
           position: 'absolute',
-          bottom: isDesktop
-            ? 56
-            : 'calc(var(--ew-story-bottom-safe, 0px) + 56px)',
+          bottom: isDesktop ? 56 : 'var(--ew-story-final-signoff-bottom, 56px)',
           left: 32,
           right: 32,
           zIndex: 15,

--- a/components/cards/ForestCard.tsx
+++ b/components/cards/ForestCard.tsx
@@ -7,13 +7,11 @@ import { StatBlock, StatLadder, StatSourceMeta } from "./StatBlock";
 import { EarthQuote, StatLabel, HorizonLine } from "@/components/ui/CardTypography";
 import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
 import { useEarthVoice } from "@/hooks/useEarthVoice";
-import { useMediaMin } from "@/hooks/useBreakpoint";
 
 const accent = ACCENTS.forest;
 
 export function ForestCard({ active, onNext, onShare, grainLevel, voiceTone }: CardCommonProps) {
   const quote = useEarthVoice("forest", voiceTone);
-  const isDesktop = useMediaMin(1024);
 
   return (
     <CardShell
@@ -81,7 +79,7 @@ export function ForestCard({ active, onNext, onShare, grainLevel, voiceTone }: C
 
       <StatLabel>Forest I lost this year</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/cards/LocationCard.tsx
+++ b/components/cards/LocationCard.tsx
@@ -60,6 +60,7 @@ export function LocationCard({
       onNext={onNext}
       onShare={onShare}
       clickable={false}
+      hideNext={!!detected}
       nextLabel={detected ? 'Next' : 'Skip'}
     >
       <Globe accent={accent} active={!!detected} />
@@ -177,7 +178,7 @@ export function LocationCard({
       <div
         style={{
           position: 'absolute',
-          bottom: 110,
+          bottom: isDesktop ? 110 : 'var(--ew-story-location-actions-bottom, 110px)',
           left: isDesktop ? '50%' : 32,
           right: isDesktop ? 'auto' : 32,
           width: isDesktop ? 'min(480px, calc(100vw - 96px))' : 'auto',

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -108,9 +108,7 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              top: isDesktop
-                ? 180
-                : "calc(var(--ew-story-top-safe, 20px) + clamp(68px, 12svh, 104px))",
+              top: isDesktop ? 180 : "var(--ew-story-pledge-title-top, 112px)",
               left: isDesktop ? 32 : 24,
               right: isDesktop ? 32 : 24,
               textAlign: "center",
@@ -149,9 +147,7 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              top: isDesktop
-                ? 340
-                : "calc(var(--ew-story-top-safe, 20px) + clamp(166px, 27svh, 224px))",
+              top: isDesktop ? 340 : "var(--ew-story-pledge-form-top, 220px)",
               left: isDesktop ? "50%" : 24,
               right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",
@@ -372,9 +368,7 @@ export function PledgeCard({
           <div
             style={{
               position: "absolute",
-              bottom: isDesktop
-                ? 80
-                : "calc(var(--ew-story-bottom-safe, 0px) + 26px)",
+              bottom: isDesktop ? 80 : "var(--ew-story-action-bottom, 26px)",
               left: isDesktop ? "50%" : 24,
               right: isDesktop ? "auto" : 24,
               width: isDesktop ? "min(560px, calc(100vw - 96px))" : "auto",

--- a/components/cards/SpeciesCard.tsx
+++ b/components/cards/SpeciesCard.tsx
@@ -7,13 +7,11 @@ import { StatBlock, StatLadder, StatSourceMeta } from "./StatBlock";
 import { EarthQuote, StatLabel, HorizonLine } from "@/components/ui/CardTypography";
 import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
 import { useEarthVoice } from "@/hooks/useEarthVoice";
-import { useMediaMin } from "@/hooks/useBreakpoint";
 
 const accent = ACCENTS.species;
 
 export function SpeciesCard({ active, onNext, onShare, grainLevel, voiceTone }: CardCommonProps) {
   const quote = useEarthVoice("species", voiceTone);
-  const isDesktop = useMediaMin(1024);
 
   return (
     <CardShell
@@ -80,7 +78,7 @@ export function SpeciesCard({ active, onNext, onShare, grainLevel, voiceTone }: 
 
       <StatLabel>Species on my list</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote bottom={isDesktop ? undefined : 64}>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/ui/CardChrome.tsx
+++ b/components/ui/CardChrome.tsx
@@ -24,7 +24,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: "calc(var(--ew-story-bottom-safe, 0px) + 28px)",
+          bottom: "var(--ew-story-nav-bottom, 28px)",
           left: 0,
           right: 0,
           zIndex: 25,
@@ -114,7 +114,7 @@ export function CardChrome({
       <div
         style={{
           position: "absolute",
-          bottom: "calc(var(--ew-story-bottom-safe, 0px) + 8px)",
+          bottom: "var(--ew-story-footer-bottom, 8px)",
           left: 0,
           right: 0,
           zIndex: 25,

--- a/components/ui/CardMeta.tsx
+++ b/components/ui/CardMeta.tsx
@@ -20,7 +20,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
         className="ew-card-meta"
         style={{
           position: 'absolute',
-          top: isDesktop ? 48 : 'calc(var(--ew-story-top-safe, 20px) + 28px)',
+          top: isDesktop ? 48 : 'var(--ew-story-meta-top, 52px)',
           left: isDesktop ? '4vw' : 24,
           right: isDesktop ? '4vw' : 24,
           zIndex: 20,
@@ -47,7 +47,7 @@ export function CardMeta({ active, chapter }: CardMetaProps) {
           className="ew-card-chapter"
           style={{
             position: 'absolute',
-            top: isDesktop ? 48 : 'calc(var(--ew-story-top-safe, 20px) + 66px)',
+            top: isDesktop ? 48 : 'var(--ew-story-chapter-top, 90px)',
             left: isDesktop ? '50%' : 24,
             transform: isDesktop ? 'translateX(-50%)' : undefined,
             width: isDesktop ? 'min(52vw, 620px)' : undefined,

--- a/components/ui/CardTypography.tsx
+++ b/components/ui/CardTypography.tsx
@@ -7,24 +7,24 @@ import type { Accent } from '@/types';
 
 type EarthQuoteProps = {
   children: ReactNode;
-  bottom?: number;
+  bottom?: CSSProperties['bottom'];
   left?: number;
   right?: number;
 };
 
 type StatLabelProps = {
   children: ReactNode;
-  bottom?: number;
+  bottom?: CSSProperties['bottom'];
 };
 
 type HorizonLineProps = {
   accent: Accent;
-  bottom?: number;
+  bottom?: CSSProperties['bottom'];
 };
 
 export function EarthQuote({
   children,
-  bottom = 90,
+  bottom = 'var(--ew-story-quote-bottom, 90px)',
   left = 32,
   right = 32,
 }: EarthQuoteProps) {
@@ -71,7 +71,10 @@ export function EarthQuote({
   );
 }
 
-export function StatLabel({ children, bottom = 180 }: StatLabelProps) {
+export function StatLabel({
+  children,
+  bottom = 'var(--ew-story-stat-label-bottom, 180px)',
+}: StatLabelProps) {
   return (
     <div
       style={{
@@ -94,7 +97,10 @@ export function StatLabel({ children, bottom = 180 }: StatLabelProps) {
   );
 }
 
-export function HorizonLine({ accent, bottom = 158 }: HorizonLineProps) {
+export function HorizonLine({
+  accent,
+  bottom = 'var(--ew-story-horizon-bottom, 158px)',
+}: HorizonLineProps) {
   return (
     <div
       style={{

--- a/components/ui/SwipeContainer.tsx
+++ b/components/ui/SwipeContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useSwipe } from "@/hooks/useSwipe";
 
 type SwipeContainerProps = {
@@ -8,13 +8,12 @@ type SwipeContainerProps = {
   onPrev: () => void;
   children: ReactNode;
   className?: string;
-  style?: CSSProperties;
 };
 
-export function SwipeContainer({ onNext, onPrev, children, className, style }: SwipeContainerProps) {
+export function SwipeContainer({ onNext, onPrev, children, className }: SwipeContainerProps) {
   const handlers = useSwipe({ onNext, onPrev });
   return (
-    <div className={className} {...handlers} style={{ ...style, touchAction: "pan-y" }}>
+    <div className={className} {...handlers} style={{ touchAction: "pan-y" }}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Refactor the mobile story shell so iPhone Safari layout behavior is driven by a single CSS-based contract rather than scattered runtime viewport fixes.

## What changed

### Mobile shell authority
- moved viewport sizing and safe-area ownership into `app/globals.css`
- `MobileStory` now focuses on story state, body-lock class, card selection, and
  mobile interactions instead of viewport math

### Shared mobile layout contract
- centralized named shell variables for:
  - top-safe spacing
  - bottom-safe spacing
  - nav position
  - footer position
  - quote position
  - pledge layout positions
  - final-card lower layout
  - location action placement

### Removed fragile reserve logic
- removed `visualViewport` sizing/injection from `MobileStory`
- removed the hardcoded iPhone `92px` reserve
- reduced scattered `calc(var(--ew-story-bottom-safe) + ...)` positioning logic
  across child components

### Component updates
- updated shared UI consumers to read from the shell layout contract:
  - `CardChrome`
  - `CardMeta`
  - `CardTypography`
  - `SwipeContainer`
- updated targeted card consumers:
  - `LocationCard`
  - `PledgeCard`
  - `FinalCard`
  - `CO2Card`
  - `ForestCard`
  - `SpeciesCard`


## Validation

- `npm run lint` passes
- `npm run build` passes
