### PR TITLE
fix(mobile): correct stat-card layout and Safari bottom background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: radial-gradient(ellipse at 50% 40%, #0b0d14 0%, #050608 70%);
+  background: var(--ew-bg-bottom);
   color: var(--ew-ash);
   font-family: "JetBrains Mono", ui-monospace, monospace;
 }
@@ -508,13 +508,13 @@ body {
 html.ew-story-locked,
 body.ew-story-locked {
   overscroll-behavior: none;
+  background: var(--ew-bg-bottom);
 }
 
 body.ew-story-locked {
   width: 100%;
   min-height: 100%;
   overflow: hidden;
-  background: #0a0e1a;
 }
 
 .ew-stage {
@@ -522,11 +522,14 @@ body.ew-story-locked {
   --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);
   --ew-story-meta-top: calc(var(--ew-story-top-safe) + 28px);
   --ew-story-chapter-top: calc(var(--ew-story-top-safe) + 66px);
-  --ew-story-nav-bottom: calc(var(--ew-story-bottom-safe) + 18px);
-  --ew-story-footer-bottom: calc(var(--ew-story-bottom-safe) + 4px);
-  --ew-story-quote-bottom: calc(var(--ew-story-nav-bottom) + 58px);
+  --ew-story-nav-bottom: max(18px, var(--ew-story-bottom-safe));
+  --ew-story-footer-bottom: max(4px, calc(var(--ew-story-bottom-safe) - 20px));
+  --ew-story-quote-bottom: calc(var(--ew-story-nav-bottom) + 72px);
   --ew-story-stat-label-bottom: 180px;
   --ew-story-horizon-bottom: 158px;
+  --ew-story-stat-meta-top: 196px;
+  --ew-story-stat-shift: -10px;
+  --ew-story-stat-max-font: 178px;
   --ew-story-location-actions-bottom: calc(var(--ew-story-nav-bottom) + 58px);
   --ew-story-pledge-title-top: calc(
     var(--ew-story-top-safe) + clamp(68px, 12svh, 104px)
@@ -546,7 +549,7 @@ body.ew-story-locked {
   height: 100dvh;
   min-height: 100svh;
   overflow: hidden;
-  background: #0a0e1a;
+  background: var(--ew-bg-bottom);
   overscroll-behavior: none;
 }
 
@@ -557,7 +560,7 @@ body.ew-story-locked {
   min-height: 0;
   padding: 0;
   box-sizing: border-box;
-  background-color: #0a0e1a;
+  background-color: var(--ew-bg-bottom);
   overflow: hidden;
 }
 
@@ -586,7 +589,7 @@ body.ew-story-locked {
   border-radius: 0;
   overflow: hidden;
   z-index: 2;
-  background: #0a0e1a;
+  background: var(--ew-bg-bottom);
 }
 
 .ew-stage-meta,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   viewportFit: 'cover',
+  themeColor: '#070A12',
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/components/cards/IceCard.tsx
+++ b/components/cards/IceCard.tsx
@@ -59,7 +59,6 @@ export function IceCard({ active, onNext, onShare, grainLevel, voiceTone }: Card
 
       <StatLadder
         accent={accent}
-        top={260}
         rows={[
           { left: "— GREENLAND", right: "· 270 GT" },
           { left: "— ANTARCTICA", right: "· 150 GT" },
@@ -69,7 +68,6 @@ export function IceCard({ active, onNext, onShare, grainLevel, voiceTone }: Card
         ]}
       />
       <StatSourceMeta
-        top={260}
         rows={["SRC: NASA GRACE-FO", "SRC: NSIDC"]}
         dim={["CRYOSPHERE", "ANNUAL NET"]}
       />

--- a/components/cards/RenewablesCard.tsx
+++ b/components/cards/RenewablesCard.tsx
@@ -96,7 +96,6 @@ export function RenewablesCard({
 
       <StatLadder
         accent={accent}
-        top={260}
         rows={[
           { left: '— SOLAR', right: '· +42%' },
           { left: '— WIND', right: '· +18%' },
@@ -106,7 +105,6 @@ export function RenewablesCard({
         ]}
       />
       <StatSourceMeta
-        top={260}
         rows={['SRC: IEA', 'SRC: IRENA']}
         dim={['CAPACITY ADDED', 'YOY · GW']}
       />

--- a/components/cards/StatBlock.tsx
+++ b/components/cards/StatBlock.tsx
@@ -18,11 +18,11 @@ type StatBlockProps = {
 type StatLadderProps = {
   accent: Accent;
   rows: Array<{ left: string; right: string; active?: boolean; warn?: boolean }>;
-  top?: number;
+  top?: CSSProperties["top"];
 };
 
 type StatSourceMetaProps = {
-  top?: number;
+  top?: CSSProperties["top"];
   rows: string[];
   dim?: string[];
 };
@@ -63,7 +63,7 @@ export function StatBlock({
         style={{
           position: "relative",
           textAlign: "center",
-          transform: `translateY(${translateY}px)`,
+          transform: `translateY(var(--ew-story-stat-shift, ${translateY}px))`,
         }}
       >
         <div style={halo} />
@@ -88,7 +88,8 @@ export function StatBlock({
             "--ew-stat-desktop-size": desktopFontSize ?? `${fontSize}px`,
             fontFamily: FONTS.SERIF,
             fontWeight: 400,
-            fontSize: "var(--ew-stat-mobile-size)",
+            fontSize:
+              "min(var(--ew-stat-mobile-size), var(--ew-story-stat-max-font, var(--ew-stat-mobile-size)))",
             lineHeight: 0.82,
             letterSpacing: "-0.05em",
             color: PALETTE.ASH,
@@ -116,7 +117,11 @@ export function StatBlock({
   );
 }
 
-export function StatLadder({ accent, rows, top = 258 }: StatLadderProps) {
+export function StatLadder({
+  accent,
+  rows,
+  top = "var(--ew-story-stat-meta-top, 258px)",
+}: StatLadderProps) {
   return (
     <div
       className="ew-stat-ladder"
@@ -153,7 +158,11 @@ export function StatLadder({ accent, rows, top = 258 }: StatLadderProps) {
   );
 }
 
-export function StatSourceMeta({ top = 258, rows, dim = [] }: StatSourceMetaProps) {
+export function StatSourceMeta({
+  top = "var(--ew-story-stat-meta-top, 258px)",
+  rows,
+  dim = [],
+}: StatSourceMetaProps) {
   return (
     <div
       className="ew-stat-sources"

--- a/components/cards/TempCard.tsx
+++ b/components/cards/TempCard.tsx
@@ -34,7 +34,6 @@ export function TempCard({ active, onNext, onShare, grainLevel, voiceTone }: Car
 
       <StatLadder
         accent={accent}
-        top={230}
         rows={[
           { left: "— 0.00", right: "baseline" },
           { left: "— 0.54", right: "1980" },


### PR DESCRIPTION
## Summary

Fix the remaining iPhone Safari mobile layout issues in the shared stat-card
stack and bottom background treatment.

## Changes

- moved mobile stat metadata positioning into shared shell variables
- removed per-card hardcoded stat metadata offsets
- reduced bottom nav/footer lift so controls sit lower on Safari
- raised quote spacing slightly to avoid lower-content compression
- unified html/body, story shell, and card-frame backgrounds
- added Safari `themeColor` to match the story background

## Validation

- `npm run lint` passes
- `npm run build` passes