### PR TITLE
fix(mobile): propagate active card background through the story shell

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,8 @@
   --ew-bg-top: #0a0e1a;
   --ew-bg-mid: #0d1322;
   --ew-bg-bottom: #070a12;
-  --ew-story-atmosphere:
+  --ew-story-card-bg: var(--ew-bg-bottom);
+  --ew-story-atmosphere-image:
     radial-gradient(
       ellipse 120% 62% at 50% 112%,
       rgba(230, 214, 190, 0.08) 0%,
@@ -13,14 +14,14 @@
     ),
     radial-gradient(
       ellipse 140% 90% at 50% 100%,
-      rgba(26, 29, 46, 0.52) 0%,
+      rgba(26, 29, 46, 0.42) 0%,
       transparent 62%
     ),
     linear-gradient(
       180deg,
-      var(--ew-bg-top) 0%,
-      var(--ew-bg-mid) 48%,
-      var(--ew-bg-bottom) 100%
+      rgba(10, 14, 26, 0.72) 0%,
+      rgba(13, 19, 34, 0.42) 48%,
+      rgba(7, 10, 18, 0.18) 100%
     );
   --ew-ash: #e6d6be;
   --ew-ash-dim: rgba(230, 214, 190, 0.55);
@@ -34,7 +35,8 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100vh;
-  background: var(--ew-story-atmosphere);
+  background-color: var(--ew-story-card-bg);
+  background-image: var(--ew-story-atmosphere-image);
   color: var(--ew-ash);
   font-family: "JetBrains Mono", ui-monospace, monospace;
 }
@@ -526,7 +528,8 @@ body {
 html.ew-story-locked,
 body.ew-story-locked {
   overscroll-behavior: none;
-  background: var(--ew-story-atmosphere);
+  background-color: var(--ew-story-card-bg);
+  background-image: var(--ew-story-atmosphere-image);
 }
 
 body.ew-story-locked {
@@ -562,12 +565,9 @@ body.ew-story-locked {
   inset: 0;
   width: 100%;
   max-width: 100%;
-  height: 100vh;
-  height: 100svh;
-  height: 100dvh;
-  min-height: 100svh;
   overflow: hidden;
-  background: var(--ew-story-atmosphere);
+  background-color: var(--ew-story-card-bg);
+  background-image: var(--ew-story-atmosphere-image);
   overscroll-behavior: none;
 }
 
@@ -578,7 +578,8 @@ body.ew-story-locked {
   min-height: 0;
   padding: 0;
   box-sizing: border-box;
-  background: var(--ew-story-atmosphere);
+  background-color: var(--ew-story-card-bg);
+  background-image: var(--ew-story-atmosphere-image);
   overflow: hidden;
 }
 
@@ -607,7 +608,8 @@ body.ew-story-locked {
   border-radius: 0;
   overflow: hidden;
   z-index: 2;
-  background: var(--ew-story-atmosphere);
+  background-color: var(--ew-story-card-bg);
+  background-image: var(--ew-story-atmosphere-image);
 }
 
 .ew-stage-meta,

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   ACTIVE_STORAGE_KEY,
@@ -109,6 +109,16 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   const cardId: CardId = CARD_IDS[active];
   const isInteractive = INTERACTIVE_CARD_IDS.has(cardId);
   const bg = CARD_BACKGROUNDS[cardId];
+
+  useLayoutEffect(() => {
+    document.documentElement.style.setProperty("--ew-story-card-bg", bg);
+    document.body.style.setProperty("--ew-story-card-bg", bg);
+
+    return () => {
+      document.documentElement.style.removeProperty("--ew-story-card-bg");
+      document.body.style.removeProperty("--ew-story-card-bg");
+    };
+  }, [bg]);
 
   const common = {
     active,

--- a/components/cards/IntroCard.tsx
+++ b/components/cards/IntroCard.tsx
@@ -1,15 +1,20 @@
-"use client";
+'use client';
 
-import { motion } from "framer-motion";
-import { PALETTE, FONTS, ACCENTS } from "@/constants/colors";
-import type { CardCommonProps } from "@/types";
-import { CardShell } from "./CardShell";
-import { EarthQuote } from "@/components/ui/CardTypography";
-import { useMediaMin } from "@/hooks/useBreakpoint";
+import { motion } from 'framer-motion';
+import { PALETTE, FONTS, ACCENTS } from '@/constants/colors';
+import type { CardCommonProps } from '@/types';
+import { CardShell } from './CardShell';
+import { EarthQuote } from '@/components/ui/CardTypography';
+import { useMediaMin } from '@/hooks/useBreakpoint';
 
 const accent = ACCENTS.intro;
 
-export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonProps) {
+export function IntroCard({
+  active,
+  onNext,
+  onShare,
+  grainLevel,
+}: CardCommonProps) {
   const isDesktop = useMediaMin(1024);
 
   return (
@@ -23,17 +28,17 @@ export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonPro
     >
       <div
         style={{
-          position: "absolute",
+          position: 'absolute',
           top: 170,
           left: 0,
           right: 0,
-          textAlign: "center",
+          textAlign: 'center',
           fontFamily: FONTS.SERIF,
           fontSize: 80,
           lineHeight: 1,
           color: PALETTE.ASH_FAINT,
-          fontStyle: "italic",
-          letterSpacing: "0.05em",
+          fontStyle: 'italic',
+          letterSpacing: '0.05em',
           zIndex: 4,
         }}
       >
@@ -45,15 +50,15 @@ export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonPro
         animate={{ opacity: 1 }}
         transition={{ delay: 0.6, duration: 1 }}
         style={{
-          position: "absolute",
+          position: 'absolute',
           top: 270,
           left: 0,
           right: 0,
-          textAlign: "center",
+          textAlign: 'center',
           fontFamily: FONTS.MONO,
           fontSize: 10,
-          letterSpacing: "0.3em",
-          textTransform: "uppercase",
+          letterSpacing: '0.3em',
+          textTransform: 'uppercase',
           color: PALETTE.ASH_DIMMER,
           zIndex: 4,
         }}
@@ -63,20 +68,20 @@ export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonPro
 
       <div
         style={{
-          position: "absolute",
+          position: 'absolute',
           top: isDesktop ? 285 : 310,
           left: 32,
           right: 32,
           fontFamily: FONTS.SERIF,
-          fontSize: isDesktop ? "clamp(54px, 5vw, 76px)" : 36,
+          fontSize: isDesktop ? 'clamp(54px, 5vw, 76px)' : 36,
           lineHeight: isDesktop ? 1.05 : 1.15,
           color: PALETTE.ASH,
-          fontStyle: "italic",
+          fontStyle: 'italic',
           fontWeight: 400,
-          letterSpacing: "-0.02em",
-          textAlign: "center",
+          letterSpacing: '-0.02em',
+          textAlign: 'center',
           zIndex: 5,
-          textWrap: "balance",
+          textWrap: 'balance',
         }}
       >
         <motion.div
@@ -104,16 +109,16 @@ export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonPro
 
       <div
         style={{
-          position: "absolute",
+          position: 'absolute',
           bottom: 100,
           left: 24,
           zIndex: 15,
           fontFamily: FONTS.MONO,
           fontSize: 8.5,
-          letterSpacing: "0.18em",
+          letterSpacing: '0.18em',
           color: PALETTE.ASH_DIMMER,
           lineHeight: 1.8,
-          textTransform: "uppercase",
+          textTransform: 'uppercase',
         }}
       >
         <div>Filed: 2026.04.17</div>
@@ -121,17 +126,17 @@ export function IntroCard({ active, onNext, onShare, grainLevel }: CardCommonPro
       </div>
       <div
         style={{
-          position: "absolute",
+          position: 'absolute',
           bottom: 100,
           right: 24,
           zIndex: 15,
           fontFamily: FONTS.MONO,
           fontSize: 8.5,
-          letterSpacing: "0.18em",
+          letterSpacing: '0.18em',
           color: PALETTE.ASH_DIMMER,
           lineHeight: 1.8,
-          textTransform: "uppercase",
-          textAlign: "right",
+          textTransform: 'uppercase',
+          textAlign: 'right',
         }}
       >
         <div>Vol. MMXXVI</div>


### PR DESCRIPTION
## Summary

Fix the remaining iPhone Safari mobile background seam by propagating the
active card background through the full story shell instead of only the inner
animated card layer.

## Changes

- added `--ew-story-card-bg` to the story shell contract
- split the shared shell background into:
  - explicit background color
  - shared atmosphere image
- applied the active card background across:
  - `html, body`
  - `html.ew-story-locked`
  - `body.ew-story-locked`
  - `.ew-stage`
  - `.ew-stage-bg`
  - `.ew-card-frame`
- removed explicit viewport-height sizing from `.ew-stage`
- kept `.ew-stage` at `width: 100%` with `100vw` still removed

## Validation

- `npm run lint` passes
- `npm run build` passes