### PR TITLE
fix(background): restore variation and grain visibility at story edges

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,12 @@
   --ew-story-overlay-tint: #1a1d2e;
   --ew-story-atmosphere-image:
     radial-gradient(
+      ellipse 120% 50% at 50% -15%,
+      var(--ew-story-accent-glow) 0%,
+      rgba(0, 0, 0, 0.02) 40%,
+      transparent 62%
+    ),
+    radial-gradient(
       ellipse 120% 60% at 50% 115%,
       var(--ew-story-accent-glow) 0%,
       rgba(0, 0, 0, 0.02) 35%,
@@ -23,8 +29,9 @@
     ),
     linear-gradient(
       180deg,
-      var(--ew-story-bg-top) 0%,
-      var(--ew-story-bg-mid) 45%,
+      var(--ew-story-bg-mid) 0%,
+      var(--ew-story-bg-top) 18%,
+      var(--ew-story-bg-mid) 55%,
       var(--ew-story-bg-bottom) 100%
     );
   --ew-ash: #e6d6be;

--- a/components/ui/CardBackground.tsx
+++ b/components/ui/CardBackground.tsx
@@ -34,9 +34,10 @@ export function CardBackground({
           inset: 0,
           zIndex: 0,
           background: `
+            radial-gradient(ellipse 120% 50% at 50% -15%, ${accent.glow} 0%, rgba(0,0,0,0.02) 40%, transparent 62%),
             radial-gradient(ellipse 120% 60% at 50% 115%, ${accent.glow} 0%, rgba(0,0,0,0.02) 35%, transparent 58%),
             radial-gradient(ellipse 140% 90% at 50% 100%, ${overlayTint} 0%, transparent 60%),
-            linear-gradient(180deg, ${top} 0%, ${mid} 45%, ${bottom} 100%)
+            linear-gradient(180deg, ${mid} 0%, ${top} 18%, ${mid} 55%, ${bottom} 100%)
           `,
         }}
       />


### PR DESCRIPTION
## Summary

Refine the story atmosphere so the top and bottom edges no longer read as flat, dead bands on mobile and desktop.

## What changed

- added a top-anchored accent glow to the atmosphere so the upper edge has the
  same kind of depth the lower edge already had
- reshaped the gradient progression to introduce more variation at the top
  instead of fading into a flat near-black strip
- applied the same atmosphere update in both:
  - `components/ui/CardBackground.tsx`
  - `app/globals.css`
- kept the existing CSS-variable pipeline intact for per-card glow/tint control

