### PR TITLE
refactor(background): unify story shell and card background contract

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,27 +11,26 @@
   --ew-story-overlay-tint: #1a1d2e;
   --ew-story-atmosphere-image:
     radial-gradient(
-      ellipse 120% 50% at 50% -15%,
+      ellipse 150% 60% at 50% 0%,
       var(--ew-story-accent-glow) 0%,
       rgba(0, 0, 0, 0.02) 40%,
-      transparent 62%
+      transparent 70%
     ),
     radial-gradient(
-      ellipse 120% 60% at 50% 115%,
+      ellipse 150% 60% at 50% 100%,
       var(--ew-story-accent-glow) 0%,
-      rgba(0, 0, 0, 0.02) 35%,
-      transparent 58%
+      rgba(0, 0, 0, 0.02) 40%,
+      transparent 70%
     ),
     radial-gradient(
-      ellipse 140% 90% at 50% 100%,
+      ellipse 180% 120% at 50% 50%,
       var(--ew-story-overlay-tint) 0%,
-      transparent 60%
+      transparent 65%
     ),
     linear-gradient(
       180deg,
       var(--ew-story-bg-mid) 0%,
-      var(--ew-story-bg-top) 18%,
-      var(--ew-story-bg-mid) 55%,
+      var(--ew-story-bg-top) 50%,
       var(--ew-story-bg-bottom) 100%
     );
   --ew-ash: #e6d6be;

--- a/components/ui/CardBackground.tsx
+++ b/components/ui/CardBackground.tsx
@@ -1,31 +1,13 @@
-import { PALETTE } from "@/constants/colors";
 import type { Accent, CardId } from "@/types";
 import { LargeGrain, GrainTexture } from "./Grain";
 
 type CardBackgroundProps = {
-  accent: Accent;
+  accent?: Accent;
   cardId?: CardId;
   grainLevel?: number;
 };
 
-const FOREST_STOPS = {
-  top: "#0F2A1C",
-  mid: "#0A1F14",
-  bottom: "#05120A",
-  mid2: "#122e1f",
-};
-
-export function CardBackground({
-  accent,
-  cardId,
-  grainLevel = 1,
-}: CardBackgroundProps) {
-  const isForest = cardId === "renewables";
-  const top = isForest ? FOREST_STOPS.top : PALETTE.BG_TOP;
-  const mid = isForest ? FOREST_STOPS.mid : PALETTE.BG_MID;
-  const bottom = isForest ? FOREST_STOPS.bottom : PALETTE.BG_BOTTOM;
-  const overlayTint = isForest ? FOREST_STOPS.mid2 : "#1a1d2e";
-
+export function CardBackground({ grainLevel = 1 }: CardBackgroundProps) {
   return (
     <>
       <div
@@ -33,12 +15,8 @@ export function CardBackground({
           position: "absolute",
           inset: 0,
           zIndex: 0,
-          background: `
-            radial-gradient(ellipse 120% 50% at 50% -15%, ${accent.glow} 0%, rgba(0,0,0,0.02) 40%, transparent 62%),
-            radial-gradient(ellipse 120% 60% at 50% 115%, ${accent.glow} 0%, rgba(0,0,0,0.02) 35%, transparent 58%),
-            radial-gradient(ellipse 140% 90% at 50% 100%, ${overlayTint} 0%, transparent 60%),
-            linear-gradient(180deg, ${mid} 0%, ${top} 18%, ${mid} 55%, ${bottom} 100%)
-          `,
+          backgroundColor: "var(--ew-story-bg-bottom)",
+          backgroundImage: "var(--ew-story-atmosphere-image)",
         }}
       />
       <div
@@ -50,8 +28,10 @@ export function CardBackground({
           height: 380,
           borderRadius: "50%",
           zIndex: 1,
-          background: `radial-gradient(ellipse at center top, ${accent.glow} 0%, rgba(0,0,0,0.02) 32%, transparent 60%)`,
+          background:
+            "radial-gradient(ellipse at center top, var(--ew-story-accent-glow) 0%, rgba(0,0,0,0.02) 32%, transparent 60%)",
           filter: "blur(2px)",
+          pointerEvents: "none",
         }}
       />
       <LargeGrain opacity={0.55 * grainLevel} />


### PR DESCRIPTION
## Summary

Unify the story shell and card interior background systems so they both render
from the same shared CSS-variable contract.

## What changed

- shell layers now read from the shared story background vars
- `MobileStory` writes the active card background vars to the document shell
- `DesktopStory` drives the shared accent glow through the same contract
- `CardBackground` was rewritten to use the shared story background vars
  instead of its own separate palette-driven gradient logic
- the renewables/forest override now happens once in `getStoryBgVars`
  and flows through both shell and card layers

## Validation

- `npm run build` passes