### PR TITLE
refactor(mobile): reset phone story shell architecture

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -763,6 +763,125 @@ body.ew-story-locked {
   .ew-earth-quote span {
     color: rgba(246, 239, 222, 0.52) !important;
   }
+
+}
+
+/* ───────────────────────────────────────────────────────────── */
+/* Phone story shell (≤ 767px) — fixed scene, shell-owned world */
+/* ───────────────────────────────────────────────────────────── */
+@media (max-width: 767px) {
+  html.ew-story-locked,
+  body.ew-story-locked {
+    width: 100%;
+    height: 100%;
+    min-height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
+    background-color: var(--ew-story-bg-bottom);
+    background-image: var(--ew-story-atmosphere-image);
+    background-position: center top;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+  }
+
+  .ew-stage.ew-phone-shell {
+    --ew-phone-side: 24px;
+    --ew-phone-browser-bleed: max(
+      96px,
+      calc(env(safe-area-inset-bottom, 0px) + 72px)
+    );
+    --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 22px);
+    --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);
+    --ew-story-meta-top: calc(var(--ew-story-top-safe) + 26px);
+    --ew-story-chapter-top: calc(var(--ew-story-top-safe) + 64px);
+    --ew-story-nav-bottom: max(16px, var(--ew-story-bottom-safe));
+    --ew-story-footer-bottom: max(3px, calc(var(--ew-story-bottom-safe) - 20px));
+    --ew-story-quote-bottom: calc(var(--ew-story-nav-bottom) + 74px);
+    --ew-story-stat-label-bottom: 178px;
+    --ew-story-horizon-bottom: 156px;
+    --ew-story-stat-meta-top: calc(var(--ew-story-top-safe) + 168px);
+    --ew-story-stat-shift: -10px;
+    --ew-story-stat-max-font: 176px;
+    --ew-story-location-actions-bottom: calc(var(--ew-story-nav-bottom) + 58px);
+    --ew-story-pledge-title-top: calc(
+      var(--ew-story-top-safe) + clamp(64px, 10svh, 92px)
+    );
+    --ew-story-pledge-form-top: calc(
+      var(--ew-story-top-safe) + clamp(154px, 25svh, 208px)
+    );
+    --ew-story-action-bottom: calc(var(--ew-story-nav-bottom) + 8px);
+    --ew-story-final-count-bottom: calc(var(--ew-story-nav-bottom) + 152px);
+    --ew-story-final-signoff-bottom: calc(var(--ew-story-nav-bottom) + 44px);
+    position: fixed;
+    inset: 0;
+    width: auto;
+    height: auto;
+    min-width: 0;
+    min-height: 0;
+    max-width: none;
+    max-height: none;
+    box-sizing: border-box;
+    overflow: hidden;
+    isolation: isolate;
+    contain: layout paint;
+    background-color: var(--ew-story-bg-bottom);
+    background-image: none;
+    overscroll-behavior: none;
+  }
+
+  .ew-stage.ew-phone-shell > .ew-phone-atmosphere {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: calc(-1 * var(--ew-phone-browser-bleed));
+    left: 0;
+    z-index: 0;
+    overflow: hidden;
+    background-color: var(--ew-story-bg-bottom);
+    background-image: var(--ew-story-atmosphere-image);
+    background-position: center top;
+    background-repeat: no-repeat;
+    background-size: 100% calc(100% + var(--ew-phone-browser-bleed));
+  }
+
+  .ew-stage.ew-phone-shell > .ew-phone-viewport,
+  .ew-stage.ew-phone-shell .ew-phone-card-content {
+    position: absolute;
+    inset: 0;
+    width: auto;
+    height: auto;
+    min-width: 0;
+    min-height: 0;
+    max-width: none;
+    max-height: none;
+    overflow: hidden;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  .ew-stage.ew-phone-shell > .ew-phone-viewport {
+    z-index: 1;
+  }
+
+  .ew-stage.ew-phone-shell .ew-phone-card-content {
+    z-index: 2;
+  }
+
+  .ew-stage.ew-phone-shell .ew-card-chrome {
+    bottom: var(--ew-story-nav-bottom) !important;
+    padding-right: var(--ew-phone-side) !important;
+    padding-left: var(--ew-phone-side) !important;
+    z-index: 30 !important;
+  }
+
+  .ew-stage.ew-phone-shell .ew-card-footer {
+    bottom: var(--ew-story-footer-bottom) !important;
+    z-index: 30 !important;
+  }
+
+  .ew-stage.ew-phone-shell .ew-story-atmosphere::after {
+    height: calc(var(--ew-phone-browser-bleed) + var(--ew-story-bottom-safe) + 168px);
+  }
 }
 
 /* ───────────────────────────────────────────────────────────── */

--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -25,6 +25,7 @@ import { SpeciesCard } from "@/components/cards/SpeciesCard";
 import { PlasticCard } from "@/components/cards/PlasticCard";
 import { RenewablesCard } from "@/components/cards/RenewablesCard";
 import { FinalCard } from "@/components/cards/FinalCard";
+import { useMediaMax } from "@/hooks/useBreakpoint";
 
 type MobileStoryProps = { tweaks: Tweaks };
 
@@ -39,6 +40,7 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   const [userLocation, setUserLocation] = useState<Location | null>(null);
   const [userPledge, setUserPledge] = useState<Pledge | null>(null);
   const [restoredActive, setRestoredActive] = useState(false);
+  const isPhone = useMediaMax(767);
 
   useEffect(() => {
     document.documentElement.classList.add("ew-story-locked");
@@ -135,9 +137,14 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
   };
 
   return (
-    <SwipeContainer onNext={next} onPrev={prev} className="ew-stage">
-      <div className="ew-story-atmosphere" aria-hidden="true" />
-      <div className="ew-stage-bg">
+    <SwipeContainer
+      onNext={next}
+      onPrev={prev}
+      className="ew-stage ew-phone-shell"
+      touchAction={isPhone ? "none" : "pan-y"}
+    >
+      <div className="ew-story-atmosphere ew-phone-atmosphere" aria-hidden="true" />
+      <div className="ew-stage-bg ew-phone-viewport">
         {!isInteractive && (
           <div className="ew-tap-zones">
             <div onClick={prev} className="ew-tap-left" />
@@ -145,7 +152,7 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
           </div>
         )}
 
-        <div className="ew-card-frame" data-card={cardId}>
+        <div className="ew-card-frame ew-phone-card-content" data-card={cardId}>
           <AnimatePresence initial={false} mode="sync">
             {cardId === "intro" && <IntroCard key="intro" {...common} />}
             {cardId === "location" && (

--- a/components/cards/CO2Card.tsx
+++ b/components/cards/CO2Card.tsx
@@ -124,7 +124,7 @@ export function CO2Card({
 
       <StatLabel>Above preindustrial</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote belowHorizonOnMobile>&ldquo;{quote}&rdquo;</EarthQuote>
       <StatSourceMeta
         rows={['SRC: NOAA GML']}
         dim={['MAUNA LOA', 'PRELIMINARY']}

--- a/components/cards/ForestCard.tsx
+++ b/components/cards/ForestCard.tsx
@@ -79,7 +79,7 @@ export function ForestCard({ active, onNext, onShare, grainLevel, voiceTone }: C
 
       <StatLabel>Forest I lost this year</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote belowHorizonOnMobile>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/cards/SpeciesCard.tsx
+++ b/components/cards/SpeciesCard.tsx
@@ -78,7 +78,7 @@ export function SpeciesCard({ active, onNext, onShare, grainLevel, voiceTone }: 
 
       <StatLabel>Species on my list</StatLabel>
       <HorizonLine accent={accent} />
-      <EarthQuote>&ldquo;{quote}&rdquo;</EarthQuote>
+      <EarthQuote belowHorizonOnMobile>&ldquo;{quote}&rdquo;</EarthQuote>
     </CardShell>
   );
 }

--- a/components/ui/CardChrome.tsx
+++ b/components/ui/CardChrome.tsx
@@ -22,6 +22,7 @@ export function CardChrome({
   return (
     <>
       <div
+        className="ew-card-chrome"
         style={{
           position: "absolute",
           bottom: "var(--ew-story-nav-bottom, 28px)",
@@ -112,6 +113,7 @@ export function CardChrome({
         )}
       </div>
       <div
+        className="ew-card-footer"
         style={{
           position: "absolute",
           bottom: "var(--ew-story-footer-bottom, 8px)",

--- a/components/ui/CardTypography.tsx
+++ b/components/ui/CardTypography.tsx
@@ -4,12 +4,14 @@ import type { CSSProperties, ReactNode } from 'react';
 import { motion } from 'framer-motion';
 import { PALETTE, FONTS } from '@/constants/colors';
 import type { Accent } from '@/types';
+import { useMediaMax } from '@/hooks/useBreakpoint';
 
 type EarthQuoteProps = {
   children: ReactNode;
   bottom?: CSSProperties['bottom'];
   left?: number;
   right?: number;
+  belowHorizonOnMobile?: boolean;
 };
 
 type StatLabelProps = {
@@ -27,10 +29,16 @@ export function EarthQuote({
   bottom = 'var(--ew-story-quote-bottom, 90px)',
   left = 32,
   right = 32,
+  belowHorizonOnMobile = false,
 }: EarthQuoteProps) {
+  const isPhone = useMediaMax(767);
+  const pinBelowHorizon = belowHorizonOnMobile && isPhone;
   const style: CSSProperties = {
     position: 'absolute',
-    bottom,
+    top: pinBelowHorizon
+      ? 'calc(100% - var(--ew-story-horizon-bottom, 158px) + 18px)'
+      : undefined,
+    bottom: pinBelowHorizon ? 'auto' : bottom,
     left,
     right,
     zIndex: 15,
@@ -46,13 +54,18 @@ export function EarthQuote({
   };
   return (
     <motion.div
-      className="ew-earth-quote"
+      className={
+        belowHorizonOnMobile
+          ? 'ew-earth-quote ew-earth-quote--below-horizon-mobile'
+          : 'ew-earth-quote'
+      }
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 1, ease: [0.2, 0.8, 0.2, 1], delay: 0.3 }}
       style={style}
     >
       <span
+        className="ew-earth-quote-source"
         style={{
           display: 'block',
           fontFamily: FONTS.MONO,
@@ -67,7 +80,7 @@ export function EarthQuote({
       >
         — Earth
       </span>
-      {children}
+      <span className="ew-earth-quote-text">{children}</span>
     </motion.div>
   );
 }

--- a/components/ui/SwipeContainer.tsx
+++ b/components/ui/SwipeContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { useSwipe } from "@/hooks/useSwipe";
 
 type SwipeContainerProps = {
@@ -8,12 +8,19 @@ type SwipeContainerProps = {
   onPrev: () => void;
   children: ReactNode;
   className?: string;
+  touchAction?: CSSProperties["touchAction"];
 };
 
-export function SwipeContainer({ onNext, onPrev, children, className }: SwipeContainerProps) {
+export function SwipeContainer({
+  onNext,
+  onPrev,
+  children,
+  className,
+  touchAction = "pan-y",
+}: SwipeContainerProps) {
   const handlers = useSwipe({ onNext, onPrev });
   return (
-    <div className={className} {...handlers} style={{ touchAction: "pan-y" }}>
+    <div className={className} {...handlers} style={{ touchAction }}>
       {children}
     </div>
   );

--- a/hooks/useBreakpoint.ts
+++ b/hooks/useBreakpoint.ts
@@ -15,3 +15,17 @@ export function useMediaMin(minWidthPx: number): boolean {
 
   return matches;
 }
+
+export function useMediaMax(maxWidthPx: number): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${maxWidthPx}px)`);
+    const apply = () => setMatches(mq.matches);
+    apply();
+    mq.addEventListener("change", apply);
+    return () => mq.removeEventListener("change", apply);
+  }, [maxWidthPx]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

Reset the phone-only story shell, so the iPhone experience is driven by a real fixed scene architecture instead of layered mobile patches.

## What changed

- added a dedicated phone breakpoint hook
- introduced explicit phone shell layers in `MobileStory`:
  - `ew-phone-shell`
  - `ew-phone-atmosphere`
  - `ew-phone-viewport`
  - `ew-phone-card-content`
- added a dedicated `@media (max-width: 767px)` phone shell contract in
  `app/globals.css`
- moved phone chrome placement onto shell-owned variables
- updated `SwipeContainer` so phone uses `touch-action: none` while tablet
  keeps `pan-y`
- scoped the affected quote-position adjustments to phone only

## Unchanged

- iPad/tablet layout and behavior
- desktop story shell and scroll behavior
- ledger page
- Solana/Neon logic

## Validation

- `npm run lint` passes
- `npm run build` passes