### PR TITLE
fix(api): harden mint verification, counts, and schema bootstrap

### DIFF
--- a/app/api/locations/route.ts
+++ b/app/api/locations/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { recentLocations, recordLocation } from "@/lib/db/locations";
+import {
+  checkRateLimit,
+  LOCATION_WRITE_RATE_LIMIT,
+  rateLimitResponse,
+} from "@/lib/rateLimit";
 
 function optionalCoordinate(value: unknown, min: number, max: number): number | null {
   if (value === null || value === undefined || value === "") return null;
@@ -15,6 +20,9 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
+  const rateLimit = checkRateLimit(req, LOCATION_WRITE_RATE_LIMIT);
+  if (!rateLimit.ok) return rateLimitResponse(rateLimit);
+
   let body: {
     country?: unknown;
     country_code?: unknown;

--- a/app/api/pledges/route.ts
+++ b/app/api/pledges/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
-  PLEDGE_COUNT_CACHE_TAG,
-  cachedCountPledges,
+  MINTED_PLEDGE_COUNT_CACHE_TAG,
+  TOTAL_PLEDGE_COUNT_CACHE_TAG,
+  cachedCountMintedPledges,
+  cachedCountTotalPledges,
   insertPledge,
   listMintedPledges,
 } from "@/lib/db/pledges";
@@ -12,6 +14,12 @@ import type { Pledge } from "@/types";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
 import { revalidateTag } from "next/cache";
 import { normalizePledgeMintMetadata } from "@/lib/solana/pledgeMintMetadata";
+import { verifyPledgeMintOnChain } from "@/lib/solana/verifyMint";
+import {
+  checkRateLimit,
+  PLEDGE_WRITE_RATE_LIMIT,
+  rateLimitResponse,
+} from "@/lib/rateLimit";
 
 function optionalCoordinate(value: unknown, min: number, max: number): number | null {
   if (value === null || value === undefined || value === "") return null;
@@ -21,15 +29,24 @@ function optionalCoordinate(value: unknown, min: number, max: number): number | 
 }
 
 export async function GET(req: NextRequest) {
-  const count = await cachedCountPledges();
+  const [totalCount, mintedCount] = await Promise.all([
+    cachedCountTotalPledges(),
+    cachedCountMintedPledges(),
+  ]);
   if (req.nextUrl.searchParams.get("ledger") !== "1") {
-    return NextResponse.json({ count });
+    return NextResponse.json({
+      totalCount,
+      mintedCount,
+      counts: { total: totalCount, minted: mintedCount },
+    });
   }
 
   const limit = Number(req.nextUrl.searchParams.get("limit") ?? 50);
   const pledges = await listMintedPledges(Number.isFinite(limit) ? limit : 50);
   return NextResponse.json({
-    count,
+    totalCount,
+    mintedCount,
+    counts: { total: totalCount, minted: mintedCount },
     pledges: pledges.map((pledge) => ({
       id: pledge.id,
       pledgeText: pledge.pledgeText,
@@ -52,6 +69,9 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
+  const rateLimit = checkRateLimit(req, PLEDGE_WRITE_RATE_LIMIT);
+  if (!rateLimit.ok) return rateLimitResponse(rateLimit);
+
   let body: {
     pledge_text?: unknown;
     text?: unknown;
@@ -100,9 +120,27 @@ export async function POST(req: NextRequest) {
         })
       : null;
 
-  const mint = normalizePledgeMintMetadata(body.mint, pledgeText);
+  let mint = normalizePledgeMintMetadata(body.mint, pledgeText);
   if (body.mint !== undefined && !mint) {
     return NextResponse.json({ error: "invalid mint metadata" }, { status: 400 });
+  }
+  if (mint) {
+    try {
+      const verification = await verifyPledgeMintOnChain(mint, pledgeText);
+      if (!verification.ok) {
+        return NextResponse.json(
+          { error: verification.error },
+          { status: verification.status },
+        );
+      }
+      mint = verification.metadata;
+    } catch (error) {
+      console.error("Failed to verify Solana mint", error);
+      return NextResponse.json(
+        { error: "mint verification unavailable" },
+        { status: 502 },
+      );
+    }
   }
   const co2PpmAtMint = mint ? (await fetchLatestCo2()).ppm : null;
   let saved: Awaited<ReturnType<typeof insertPledge>>;
@@ -119,7 +157,8 @@ export async function POST(req: NextRequest) {
     console.error("Failed to insert pledge", error);
     return NextResponse.json({ error: "pledge storage failed" }, { status: 500 });
   }
-  revalidateTag(PLEDGE_COUNT_CACHE_TAG, { expire: 0 });
+  revalidateTag(TOTAL_PLEDGE_COUNT_CACHE_TAG, { expire: 0 });
+  revalidateTag(MINTED_PLEDGE_COUNT_CACHE_TAG, { expire: 0 });
 
   if (location) {
     const locationCountry =

--- a/app/ledger/page.tsx
+++ b/app/ledger/page.tsx
@@ -6,6 +6,7 @@ import { LargeGrain, GrainTexture } from '@/components/ui/Grain';
 import { LEDGER_CSS_VARS } from '@/constants/colors';
 import type { PledgeRow } from '@/lib/db/pledges';
 import {
+  countLedgerEntries,
   formatLedgerDate,
   ledgerCountryLabel,
   ledgerExplorerHref,
@@ -157,8 +158,7 @@ async function LedgerCount() {
 
   let count: number | null = null;
   try {
-    const pledges = await listLedgerEntries(LEDGER_LIMIT);
-    count = pledges.length;
+    count = await countLedgerEntries();
   } catch {
     count = null;
   }

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -6,7 +6,7 @@ import type { CardCommonProps, Location, Pledge } from '@/types';
 import { VOICE_QUOTES } from '@/constants/quotes';
 import { CardShell } from './CardShell';
 import { FinalGlobe } from './FinalGlobe';
-import { usePledgeCount } from '@/hooks/usePledge';
+import { useMintedPledgeCount } from '@/hooks/usePledge';
 import { ENDPOINTS } from '@/constants/endpoints';
 import { useMediaMin } from '@/hooks/useBreakpoint';
 
@@ -61,7 +61,7 @@ export function FinalCard({
   userLocation,
   userPledge,
 }: FinalCardProps) {
-  const pledgeCount = usePledgeCount();
+  const mintedPledgeCount = useMintedPledgeCount();
   const [globeLocations, setGlobeLocations] = useState<Location[]>([]);
   const isDesktop = useMediaMin(1024);
   const closingLine = VOICE_QUOTES.final?.[voiceTone] ?? '';
@@ -187,7 +187,7 @@ export function FinalCard({
             textShadow: `0 0 30px ${accent.glow}`,
           }}
         >
-          {pledgeCount.toLocaleString()}
+          {mintedPledgeCount.toLocaleString()}
         </div>
         {userPledge?.minted && (
           <div

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -9,6 +9,7 @@ import { MintButton } from "@/components/ui/MintButton";
 import { useMintPledge } from "@/hooks/usePledge";
 import { useMediaMax, useMediaMin } from "@/hooks/useBreakpoint";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
+import { SOLANA_NETWORK } from "@/lib/solana/mint";
 
 type PledgeCardProps = CardCommonProps & {
   userPledge: Pledge | null;
@@ -422,7 +423,7 @@ export function PledgeCard({
                 color: PALETTE.ASH_DIMMER,
               }}
             >
-              Solana devnet is optional
+              Solana {SOLANA_NETWORK} is optional
             </div>
             {error && (
               <div

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".test-build/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/hooks/usePledge.ts
+++ b/hooks/usePledge.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { ENDPOINTS } from "@/constants/endpoints";
 import type { Pledge } from "@/types";
-import { mintPledgeOnDevnet } from "@/lib/solana/wallet";
+import { mintPledgeOnSolana } from "@/lib/solana/wallet";
 import type { PledgeMintMetadata } from "@/lib/solana/mint";
 
 const SESSION_LOCATION_KEY = "thisyearearth:session-location";
@@ -33,32 +33,55 @@ async function getApiErrorMessage(res: Response) {
   return res.statusText || `HTTP ${res.status}`;
 }
 
-export function usePledgeCount(pollMs = 30_000) {
-  const [count, setCount] = useState(0);
+type PledgeCounts = {
+  total: number;
+  minted: number;
+};
+
+export function usePledgeCounts(pollMs = 30_000) {
+  const [counts, setCounts] = useState<PledgeCounts>({ total: 0, minted: 0 });
 
   useEffect(() => {
     let cancelled = false;
 
-    const loadCount = async () => {
+    const loadCounts = async () => {
       try {
         const res = await fetch(ENDPOINTS.PLEDGES);
         if (!res.ok) return;
-        const data = (await res.json()) as { count: number };
-        if (!cancelled) setCount(data.count);
+        const data = (await res.json()) as {
+          totalCount: number;
+          mintedCount: number;
+        };
+        if (
+          typeof data.totalCount !== "number" ||
+          typeof data.mintedCount !== "number"
+        ) {
+          return;
+        }
+        if (!cancelled) {
+          setCounts({
+            total: data.totalCount,
+            minted: data.mintedCount,
+          });
+        }
       } catch {
         // ignore
       }
     };
 
-    void loadCount();
-    const id = setInterval(loadCount, pollMs);
+    void loadCounts();
+    const id = setInterval(loadCounts, pollMs);
     return () => {
       cancelled = true;
       clearInterval(id);
     };
   }, [pollMs]);
 
-  return count;
+  return counts;
+}
+
+export function useMintedPledgeCount(pollMs = 30_000) {
+  return usePledgeCounts(pollMs).minted;
 }
 
 function readSessionLocation(): SessionLocation | null {
@@ -147,7 +170,7 @@ export function useMintPledge() {
       setError(null);
       let mintMetadata: PledgeMintMetadata | null = null;
       try {
-        mintMetadata = await mintPledgeOnDevnet(text);
+        mintMetadata = await mintPledgeOnSolana(text);
         await ensureSessionLocationSaved();
         return postPledge(text, metadata, mintMetadata);
       } catch (e) {

--- a/lib/db/pledges.ts
+++ b/lib/db/pledges.ts
@@ -3,7 +3,8 @@ import { cacheLife, cacheTag } from "next/cache";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
 import type { PledgeMintMetadata, SolanaNetwork } from "@/lib/solana/mint";
 
-export const PLEDGE_COUNT_CACHE_TAG = "pledge-count";
+export const TOTAL_PLEDGE_COUNT_CACHE_TAG = "pledge-count-total";
+export const MINTED_PLEDGE_COUNT_CACHE_TAG = "pledge-count-minted";
 
 export type MintStatus = "none" | "minted";
 
@@ -160,12 +161,28 @@ export async function insertPledge(input: InsertPledgeInput): Promise<PledgeRow>
   return mapPledgeRow(saved);
 }
 
-export async function countPledges(): Promise<number> {
+export async function countTotalPledges(): Promise<number> {
   const sql = getSql();
   if (!sql) return memoryStore.length;
   const rows = (await sql`SELECT COUNT(*)::int AS n FROM pledges`) as {
     n: number;
   }[];
+  return rows[0]?.n ?? 0;
+}
+
+export async function countMintedPledges(): Promise<number> {
+  const sql = getSql();
+  if (!sql) {
+    return memoryStore.filter(
+      (pledge) => pledge.mintStatus === "minted" && pledge.txHash,
+    ).length;
+  }
+
+  const rows = (await sql`
+    SELECT COUNT(*)::int AS n
+    FROM pledges
+    WHERE mint_status = 'minted' AND tx_hash IS NOT NULL
+  `) as { n: number }[];
   return rows[0]?.n ?? 0;
 }
 
@@ -204,9 +221,16 @@ export async function listMintedPledges(limit = 50): Promise<PledgeRow[]> {
   return rows.map(mapPledgeRow);
 }
 
-export async function cachedCountPledges(): Promise<number> {
+export async function cachedCountTotalPledges(): Promise<number> {
   "use cache";
-  cacheTag(PLEDGE_COUNT_CACHE_TAG);
+  cacheTag(TOTAL_PLEDGE_COUNT_CACHE_TAG);
   cacheLife({ stale: 30, revalidate: 30, expire: 60 });
-  return countPledges();
+  return countTotalPledges();
+}
+
+export async function cachedCountMintedPledges(): Promise<number> {
+  "use cache";
+  cacheTag(MINTED_PLEDGE_COUNT_CACHE_TAG);
+  cacheLife({ stale: 30, revalidate: 30, expire: 60 });
+  return countMintedPledges();
 }

--- a/lib/ledger.ts
+++ b/lib/ledger.ts
@@ -1,10 +1,18 @@
-import { listMintedPledges, type PledgeRow } from "@/lib/db/pledges";
+import {
+  cachedCountMintedPledges,
+  listMintedPledges,
+  type PledgeRow,
+} from "@/lib/db/pledges";
 import { getSolanaDevnetExplorerUrl } from "@/lib/solana/mint";
 
 export const LEDGER_LIMIT = 100;
 
 export async function listLedgerEntries(limit = LEDGER_LIMIT) {
   return listMintedPledges(limit);
+}
+
+export async function countLedgerEntries() {
+  return cachedCountMintedPledges();
 }
 
 export function formatLedgerDate(value: Date | string | null) {

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,95 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+type RateLimitConfig = {
+  scope: string;
+  windowMs: number;
+  max: number;
+};
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+type RateLimitResult =
+  | { ok: true }
+  | { ok: false; retryAfterSeconds: number };
+
+// Instance-local protection: useful against bursts, but not a durable
+// cross-region quota for serverless scale-out.
+const buckets = new Map<string, Bucket>();
+const MAX_BUCKETS = 5_000;
+
+export const PLEDGE_WRITE_RATE_LIMIT: RateLimitConfig = {
+  scope: "pledges:write",
+  windowMs: 10 * 60 * 1000,
+  max: 6,
+};
+
+export const LOCATION_WRITE_RATE_LIMIT: RateLimitConfig = {
+  scope: "locations:write",
+  windowMs: 10 * 60 * 1000,
+  max: 30,
+};
+
+function clientKey(req: NextRequest, scope: string) {
+  const forwardedFor = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const ip =
+    forwardedFor ||
+    req.headers.get("x-real-ip") ||
+    req.headers.get("cf-connecting-ip") ||
+    "unknown";
+  return `${scope}:${ip}`;
+}
+
+function pruneExpiredBuckets(now: number) {
+  for (const [key, bucket] of buckets) {
+    if (bucket.resetAt <= now) buckets.delete(key);
+  }
+
+  if (buckets.size <= MAX_BUCKETS) return;
+  for (const key of buckets.keys()) {
+    buckets.delete(key);
+    if (buckets.size <= MAX_BUCKETS) return;
+  }
+}
+
+export function checkRateLimit(
+  req: NextRequest,
+  config: RateLimitConfig,
+): RateLimitResult {
+  const now = Date.now();
+  pruneExpiredBuckets(now);
+
+  const key = clientKey(req, config.scope);
+  const bucket = buckets.get(key);
+  if (!bucket || bucket.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + config.windowMs });
+    return { ok: true };
+  }
+
+  if (bucket.count >= config.max) {
+    return {
+      ok: false,
+      retryAfterSeconds: Math.max(
+        1,
+        Math.ceil((bucket.resetAt - now) / 1000),
+      ),
+    };
+  }
+
+  bucket.count += 1;
+  return { ok: true };
+}
+
+export function rateLimitResponse(result: Extract<RateLimitResult, { ok: false }>) {
+  return NextResponse.json(
+    { error: "too many requests" },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(result.retryAfterSeconds),
+      },
+    },
+  );
+}

--- a/lib/solana/pledgeMintMetadata.ts
+++ b/lib/solana/pledgeMintMetadata.ts
@@ -21,6 +21,7 @@ export function normalizePledgeMintMetadata(
   ) {
     return null;
   }
+  if (mint.network !== undefined && mint.network !== SOLANA_NETWORK) return null;
 
   const metadata: PledgeMintMetadata = {
     txHash: mint.txHash,

--- a/lib/solana/verifyMint.ts
+++ b/lib/solana/verifyMint.ts
@@ -1,0 +1,127 @@
+import { Connection, PublicKey } from "@solana/web3.js";
+import {
+  buildPledgeMemo,
+  getSolanaDevnetExplorerUrl,
+  SOLANA_MEMO_PROGRAM_ID,
+  SOLANA_NETWORK,
+  SOLANA_RPC_URL,
+  type PledgeMintMetadata,
+  type SolanaNetwork,
+} from "./mint";
+
+const CLUSTER_GENESIS_HASHES: Record<SolanaNetwork, string> = {
+  devnet: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG",
+  testnet: "4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY",
+};
+
+type ParsedTransaction = NonNullable<
+  Awaited<ReturnType<Connection["getParsedTransaction"]>>
+>;
+type ParsedInstruction =
+  ParsedTransaction["transaction"]["message"]["instructions"][number];
+
+export type PledgeMintVerificationResult =
+  | { ok: true; metadata: PledgeMintMetadata }
+  | { ok: false; error: string; status: number };
+
+function fail(error: string, status = 400): PledgeMintVerificationResult {
+  return { ok: false, error, status };
+}
+
+function getMemoPayload(instruction: ParsedInstruction) {
+  if (instruction.programId.toBase58() !== SOLANA_MEMO_PROGRAM_ID) return null;
+  if (!("parsed" in instruction)) return null;
+
+  const parsed = instruction.parsed;
+  if (typeof parsed === "string") return parsed;
+  if (parsed && typeof parsed === "object") {
+    const maybeMemo = (parsed as { memo?: unknown }).memo;
+    if (typeof maybeMemo === "string") return maybeMemo;
+  }
+  return null;
+}
+
+export async function verifyPledgeMintOnChain(
+  metadata: PledgeMintMetadata,
+  pledgeText: string,
+): Promise<PledgeMintVerificationResult> {
+  if (metadata.network !== SOLANA_NETWORK) {
+    return fail("mint network does not match server configuration");
+  }
+  if (metadata.memoProgramId !== SOLANA_MEMO_PROGRAM_ID) {
+    return fail("mint memo program does not match server configuration");
+  }
+
+  const expectedMemo = buildPledgeMemo(pledgeText);
+  if (metadata.memo !== expectedMemo) {
+    return fail("mint memo does not match pledge text");
+  }
+
+  let walletPublicKey: PublicKey;
+  try {
+    walletPublicKey = new PublicKey(metadata.walletAddress);
+  } catch {
+    return fail("mint wallet address is invalid");
+  }
+
+  const connection = new Connection(SOLANA_RPC_URL, "confirmed");
+  const expectedGenesisHash = CLUSTER_GENESIS_HASHES[SOLANA_NETWORK];
+  const actualGenesisHash = await connection.getGenesisHash();
+  if (actualGenesisHash !== expectedGenesisHash) {
+    return fail("configured Solana RPC does not match the expected network", 502);
+  }
+
+  const status = await connection.getSignatureStatuses([metadata.txHash], {
+    searchTransactionHistory: true,
+  });
+  const signatureStatus = status.value[0];
+  if (!signatureStatus) return fail("mint transaction was not found");
+  if (signatureStatus.err) return fail("mint transaction failed on-chain");
+  const isConfirmedEnough =
+    signatureStatus.confirmationStatus === "confirmed" ||
+    signatureStatus.confirmationStatus === "finalized" ||
+    signatureStatus.confirmations === null;
+  if (!isConfirmedEnough) {
+    return fail("mint transaction is not confirmed");
+  }
+
+  const transaction = await connection.getParsedTransaction(metadata.txHash, {
+    commitment: "confirmed",
+    maxSupportedTransactionVersion: 0,
+  });
+  if (!transaction) return fail("mint transaction was not found");
+  if (transaction.meta?.err) return fail("mint transaction failed on-chain");
+  if (!transaction.transaction.signatures.includes(metadata.txHash)) {
+    return fail("mint transaction signature does not match submitted hash");
+  }
+
+  const walletSigned = transaction.transaction.message.accountKeys.some(
+    (account) =>
+      account.signer && account.pubkey.toBase58() === walletPublicKey.toBase58(),
+  );
+  if (!walletSigned) {
+    return fail("mint wallet did not sign the transaction");
+  }
+
+  const memoMatches = transaction.transaction.message.instructions.some(
+    (instruction) => getMemoPayload(instruction) === expectedMemo,
+  );
+  if (!memoMatches) {
+    return fail("mint transaction memo does not match pledge text");
+  }
+
+  return {
+    ok: true,
+    metadata: {
+      txHash: metadata.txHash,
+      network: SOLANA_NETWORK,
+      walletAddress: walletPublicKey.toBase58(),
+      memo: expectedMemo,
+      memoProgramId: SOLANA_MEMO_PROGRAM_ID,
+      explorerUrl: getSolanaDevnetExplorerUrl(metadata.txHash),
+      mintedAt: transaction.blockTime
+        ? new Date(transaction.blockTime * 1000).toISOString()
+        : new Date().toISOString(),
+    },
+  };
+}

--- a/lib/solana/wallet.ts
+++ b/lib/solana/wallet.ts
@@ -2,10 +2,11 @@
 
 import {
   Connection,
+  LAMPORTS_PER_SOL,
   PublicKey,
   SendTransactionError,
+  Transaction,
   TransactionInstruction,
-  TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
 import { Buffer } from "buffer";
@@ -22,6 +23,8 @@ import {
 import { encodeBase58, normalizeWalletSignature } from "./signature";
 
 const MIN_TEST_CLUSTER_FEE_LAMPORTS = 10_000;
+const TEST_CLUSTER_AIRDROP_LAMPORTS = Math.floor(0.05 * LAMPORTS_PER_SOL);
+type SolanaTransaction = Transaction | VersionedTransaction;
 
 type WalletConnectResult = {
   publicKey?: { toString: () => string };
@@ -32,11 +35,11 @@ type SolanaWalletProvider = {
   publicKey?: { toString: () => string };
   connect: () => Promise<WalletConnectResult>;
   signAndSendTransaction?: (
-    transaction: VersionedTransaction,
+    transaction: SolanaTransaction,
   ) => Promise<{ signature: string | Uint8Array | number[] }>;
   signTransaction?: (
-    transaction: VersionedTransaction,
-  ) => Promise<VersionedTransaction>;
+    transaction: SolanaTransaction,
+  ) => Promise<SolanaTransaction>;
 };
 
 declare global {
@@ -85,6 +88,13 @@ function isAlreadyProcessedError(error: unknown) {
   return getErrorMessage(error).toLowerCase().includes("already been processed");
 }
 
+function firstTransactionSignature(transaction: SolanaTransaction) {
+  if (transaction instanceof VersionedTransaction) {
+    return transaction.signatures[0] ?? null;
+  }
+  return transaction.signatures[0]?.signature ?? null;
+}
+
 async function logSolanaError(
   scope: string,
   error: unknown,
@@ -125,7 +135,55 @@ async function connectWallet(provider: SolanaWalletProvider) {
   return publicKey;
 }
 
-export async function mintPledgeOnDevnet(
+async function ensureTestClusterFeeBalance(
+  connection: Connection,
+  feePayer: PublicKey,
+) {
+  const balance = await connection.getBalance(feePayer, "confirmed");
+  if (balance >= MIN_TEST_CLUSTER_FEE_LAMPORTS) return balance;
+
+  try {
+    const signature = await connection.requestAirdrop(
+      feePayer,
+      TEST_CLUSTER_AIRDROP_LAMPORTS,
+    );
+    const latestBlockhash = await connection.getLatestBlockhash("confirmed");
+    await connection.confirmTransaction(
+      { signature, ...latestBlockhash },
+      "confirmed",
+    );
+  } catch (error) {
+    await logSolanaError("airdrop", error, connection);
+    throw new Error(
+      `${SOLANA_NETWORK} faucet is unavailable. Add ${SOLANA_NETWORK} SOL in Phantom and try again.`,
+    );
+  }
+
+  const refreshedBalance = await connection.getBalance(feePayer, "confirmed");
+  if (refreshedBalance < MIN_TEST_CLUSTER_FEE_LAMPORTS) {
+    throw new Error(
+      `Wallet needs ${SOLANA_NETWORK} SOL before minting. Add ${SOLANA_NETWORK} SOL in Phantom and try again.`,
+    );
+  }
+  return refreshedBalance;
+}
+
+async function assertLocalSimulationPasses(
+  connection: Connection,
+  transaction: Transaction,
+) {
+  const simulation = await connection.simulateTransaction(transaction);
+  logSolanaDebug("simulate", {
+    err: simulation.value.err,
+    logs: simulation.value.logs,
+    unitsConsumed: simulation.value.unitsConsumed,
+  });
+  if (simulation.value.err) {
+    throw new Error("Solana simulation failed before wallet signing.");
+  }
+}
+
+export async function mintPledgeOnSolana(
   pledgeText: string,
 ): Promise<PledgeMintMetadata> {
   const provider = getBrowserWalletProvider();
@@ -136,12 +194,7 @@ export async function mintPledgeOnDevnet(
   const walletAddress = await connectWallet(provider);
   const connection = new Connection(SOLANA_RPC_URL, "confirmed");
   const feePayer = new PublicKey(walletAddress);
-  const balance = await connection.getBalance(feePayer, "confirmed");
-  if (balance < MIN_TEST_CLUSTER_FEE_LAMPORTS) {
-    throw new Error(
-      `Wallet needs ${SOLANA_NETWORK} SOL before minting. Add ${SOLANA_NETWORK} SOL in Phantom and try again.`,
-    );
-  }
+  const balance = await ensureTestClusterFeeBalance(connection, feePayer);
 
   const memo = buildPledgeMemo(pledgeText);
   const memoPayload = Buffer.from(new TextEncoder().encode(memo));
@@ -152,12 +205,11 @@ export async function mintPledgeOnDevnet(
     programId: new PublicKey(SOLANA_MEMO_PROGRAM_ID),
     data: memoPayload,
   });
-  const message = new TransactionMessage({
-    payerKey: feePayer,
+
+  const transaction = new Transaction({
+    feePayer,
     recentBlockhash: latestBlockhash.blockhash,
-    instructions: [memoInstruction],
-  }).compileToV0Message();
-  const transaction = new VersionedTransaction(message);
+  }).add(memoInstruction);
 
   logSolanaDebug("prepare", {
     walletAddress,
@@ -171,17 +223,19 @@ export async function mintPledgeOnDevnet(
     memo,
     memoBytes: memoPayload.length,
     debugMemo: SOLANA_DEBUG_MEMO_ENABLED,
-    transactionVersion: 0,
+    transactionVersion: "legacy",
     instructionProgramIds: [memoInstruction.programId.toBase58()],
-    instructionKeys: [memoInstruction.keys],
+    instructionKeys: memoInstruction.keys.map((key) => ({
+      pubkey: key.pubkey.toBase58(),
+      isSigner: key.isSigner,
+      isWritable: key.isWritable,
+    })),
   });
+  await assertLocalSimulationPasses(connection, transaction);
 
   let txHash: string;
   try {
-    if (provider.signAndSendTransaction) {
-      const result = await provider.signAndSendTransaction(transaction);
-      txHash = normalizeWalletSignature(result.signature);
-    } else if (provider.signTransaction) {
+    if (provider.signTransaction) {
       const signed = await provider.signTransaction(transaction);
       try {
         txHash = await connection.sendRawTransaction(signed.serialize(), {
@@ -189,13 +243,16 @@ export async function mintPledgeOnDevnet(
           maxRetries: 3,
         });
       } catch (error) {
-        const signature = signed.signatures[0];
+        const signature = firstTransactionSignature(signed);
         if (isAlreadyProcessedError(error) && signature) {
           txHash = encodeBase58(signature);
         } else {
           throw error;
         }
       }
+    } else if (provider.signAndSendTransaction) {
+      const result = await provider.signAndSendTransaction(transaction);
+      txHash = normalizeWalletSignature(result.signature);
     } else {
       throw new Error("Wallet does not support transaction signing.");
     }

--- a/migrations/000_bootstrap_base_schema.sql
+++ b/migrations/000_bootstrap_base_schema.sql
@@ -1,0 +1,38 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS pledges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  pledge_text TEXT NOT NULL,
+  name TEXT,
+  country TEXT,
+  country_code TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT pledges_pledge_text_length_check
+    CHECK (char_length(pledge_text) BETWEEN 3 AND 80),
+  CONSTRAINT pledges_country_code_length_check
+    CHECK (country_code IS NULL OR char_length(country_code) = 2)
+);
+
+CREATE INDEX IF NOT EXISTS pledges_created_at_idx
+  ON pledges (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS locations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  country TEXT NOT NULL,
+  country_code TEXT NOT NULL,
+  lat DOUBLE PRECISION,
+  lng DOUBLE PRECISION,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT locations_country_code_length_check
+    CHECK (char_length(country_code) = 2),
+  CONSTRAINT locations_lat_check
+    CHECK (lat IS NULL OR (lat >= -90 AND lat <= 90)),
+  CONSTRAINT locations_lng_check
+    CHECK (lng IS NULL OR (lng >= -180 AND lng <= 180))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS locations_country_coords_unique
+  ON locations (country_code, lat, lng) NULLS NOT DISTINCT;
+
+CREATE INDEX IF NOT EXISTS locations_created_at_idx
+  ON locations (created_at DESC);

--- a/tests/solana-mint.test.ts
+++ b/tests/solana-mint.test.ts
@@ -89,6 +89,18 @@ test("rejects invalid mint metadata before saving a pledge", () => {
       {
         txHash: VALID_SIGNATURE,
         walletAddress: VALID_WALLET,
+        network: SOLANA_NETWORK === "devnet" ? "testnet" : "devnet",
+        mintedAt: VALID_MINTED_AT,
+      },
+      PLEDGE_TEXT,
+    ),
+    null,
+  );
+  assert.equal(
+    normalizePledgeMintMetadata(
+      {
+        txHash: VALID_SIGNATURE,
+        walletAddress: VALID_WALLET,
         mintedAt: "not a date",
       },
       PLEDGE_TEXT,


### PR DESCRIPTION
## Summary

Tighten the trust and deployability path for pledges, locations, and ledger reads.

## Changes

- added server-side mint verification before storing minted records
- separated minted counts from total counts
- added basic rate limiting to public write endpoints
- fixed ESLint to ignore generated `.test-build/**` artifacts
- added a checked-in base schema bootstrap migration
- kept the existing mint metadata migration as the follow-up schema step

## Validation

- `npm run lint` passes
- `npm run build` passes
- `npm test` passes
- `git diff --check` passes