### PR TITLE
feat(pledges): add public pledges page and unify pledge record flow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -557,6 +557,53 @@ body.ew-story-locked {
   overflow: hidden;
 }
 
+@keyframes ew-final-share-rainbow {
+  0%,
+  100% {
+    filter: hue-rotate(0deg);
+    box-shadow:
+      0 0 0 rgba(230, 214, 190, 0),
+      0 0 18px rgba(77, 201, 255, 0.2);
+    transform: translateZ(0) scale(1);
+  }
+
+  50% {
+    filter: hue-rotate(180deg);
+    box-shadow:
+      0 0 14px rgba(255, 195, 113, 0.34),
+      0 0 34px rgba(167, 139, 250, 0.28);
+    transform: translateZ(0) scale(1.04);
+  }
+}
+
+[data-card="final"] .ew-share-button {
+  position: relative;
+  border-color: transparent !important;
+  background:
+    linear-gradient(rgba(230, 214, 190, 0.06), rgba(230, 214, 190, 0.06)) padding-box,
+    conic-gradient(
+      from 0deg,
+      #ff5f6d,
+      #ffc371,
+      #47e891,
+      #4dc9ff,
+      #a78bfa,
+      #ff5f6d
+    ) border-box !important;
+  animation: ew-final-share-rainbow 2.4s linear infinite;
+}
+
+[data-card="final"] .ew-share-button:hover,
+[data-card="final"] .ew-share-button:focus-visible {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-card="final"] .ew-share-button {
+    animation: none;
+  }
+}
+
 .ew-stage {
   --ew-story-top-safe: max(env(safe-area-inset-top, 0px), 24px);
   --ew-story-bottom-safe: env(safe-area-inset-bottom, 0px);

--- a/app/pledges/page.tsx
+++ b/app/pledges/page.tsx
@@ -1,0 +1,199 @@
+import type { ReactNode } from 'react';
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { connection } from 'next/server';
+import { SITE } from '@/config/site';
+import { LargeGrain, GrainTexture } from '@/components/ui/Grain';
+import { LEDGER_CSS_VARS } from '@/constants/colors';
+import {
+  cachedCountTotalPledges,
+  listPledges,
+  type PledgeRow,
+} from '@/lib/db/pledges';
+import {
+  formatLedgerDate,
+  ledgerCountryLabel,
+  LEDGER_LIMIT,
+} from '@/lib/ledger';
+
+function PledgeState({
+  tone = 'empty',
+  heading,
+  children,
+}: {
+  tone?: 'empty' | 'error';
+  heading: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`ew-ledger-state ew-ledger-state--${tone}`}>
+      <div className="ew-ledger-state-icon" />
+      <div className="ew-ledger-state-head">{heading}</div>
+      <div className="ew-ledger-state-sub">{children}</div>
+    </section>
+  );
+}
+
+function PledgesLoading() {
+  return (
+    <PledgeState heading="The Pledges Are Waiting">
+      The record is still gathering.
+    </PledgeState>
+  );
+}
+
+function pledgeDate(pledge: PledgeRow) {
+  return formatLedgerDate(pledge.createdAt);
+}
+
+function PledgeEntry({
+  pledge,
+  number,
+}: {
+  pledge: PledgeRow;
+  number: number;
+}) {
+  return (
+    <article className="ew-ledger-entry">
+      <div className="ew-ledger-meta">
+        <span className="ew-ledger-number">
+          #{String(number).padStart(4, '0')}
+        </span>
+        <span className="ew-ledger-address">
+          {ledgerCountryLabel(pledge)}
+          <span className="ew-ledger-sep">·</span>
+          {pledgeDate(pledge)}
+        </span>
+      </div>
+
+      <div className="ew-ledger-entry-pledge">{pledge.pledgeText}</div>
+      <div className="ew-ledger-author">{pledge.name || 'Anonymous'}</div>
+
+      {pledge.co2PpmAtMint ? (
+        <div className="ew-ledger-entry-foot">
+          <div className="ew-ledger-telemetry" aria-label="Pledge telemetry">
+            <span className="ew-ledger-telemetry-item">
+              CO2{' '}
+              <span className="ew-ledger-telemetry-value">
+                {pledge.co2PpmAtMint} PPM
+              </span>
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+async function PledgeEntries() {
+  await connection();
+
+  let pledges: PledgeRow[] | null = null;
+  try {
+    pledges = await listPledges(LEDGER_LIMIT);
+  } catch {
+    pledges = null;
+  }
+
+  if (!pledges) {
+    return (
+      <PledgeState tone="error" heading="Temporarily Unavailable">
+        The pledges are still there. The record is just catching its breath.
+      </PledgeState>
+    );
+  }
+
+  if (pledges.length === 0) {
+    return (
+      <PledgeState heading="The Pledges Are Waiting">
+        Be the first to show up.
+      </PledgeState>
+    );
+  }
+
+  return (
+    <>
+      <section className="ew-ledger-entries" aria-label="Public pledges">
+        {pledges.map((pledge, index) => (
+          <PledgeEntry
+            key={pledge.id}
+            pledge={pledge}
+            number={pledges.length - index}
+          />
+        ))}
+      </section>
+      <div className="ew-ledger-end">
+        End of record · {pledges.length.toLocaleString()} shown
+      </div>
+    </>
+  );
+}
+
+async function PledgeCount() {
+  await connection();
+
+  let count: number | null = null;
+  try {
+    count = await cachedCountTotalPledges();
+  } catch {
+    count = null;
+  }
+
+  return (
+    <span className="ew-ledger-count-number">
+      {count === null ? '—' : count.toLocaleString()}
+    </span>
+  );
+}
+
+export default function PledgesPage() {
+  return (
+    <main className="ew-ledger-shell" style={LEDGER_CSS_VARS}>
+      <div className="ew-ledger-fog" aria-hidden="true">
+        <LargeGrain opacity={0.12} />
+        <GrainTexture opacity={0.05} />
+      </div>
+      <div className="ew-ledger-page" data-screen-label="The Pledges">
+        <nav className="ew-ledger-nav" aria-label="Pledge navigation">
+          <div>
+            <span className="ew-ledger-dot" />
+            Wrapped · MMXXVI
+          </div>
+          <Link href="/">← Wrapped</Link>
+        </nav>
+
+        <header className="ew-ledger-lede">
+          <div className="ew-ledger-mark">the</div>
+          <h1 className="ew-ledger-title">The Pledges</h1>
+          <div className="ew-ledger-bar" />
+          <div className="ew-ledger-sub">
+            Everyone who showed up
+            <span className="ew-ledger-sep">·</span>
+            Earth Day MMXXVI
+          </div>
+          <div className="ew-ledger-count">
+            <span className="ew-ledger-live" />
+            <Suspense
+              fallback={<span className="ew-ledger-count-number">—</span>}
+            >
+              <PledgeCount />
+            </Suspense>
+            <span>Entries</span>
+          </div>
+        </header>
+
+        <Suspense fallback={<PledgesLoading />}>
+          <PledgeEntries />
+        </Suspense>
+
+        <footer className="ew-ledger-foot">
+          <div className="ew-ledger-brand">{SITE.domain}</div>
+          <Link className="ew-ledger-cta" href="/">
+            <span className="ew-ledger-arrow">←</span>
+            Write Your Pledge
+          </Link>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/components/cards/FinalCard.tsx
+++ b/components/cards/FinalCard.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import Link from 'next/link';
 import { Suspense, useEffect, useState } from 'react';
 import { PALETTE, FONTS, ACCENTS } from '@/constants/colors';
 import type { CardCommonProps, Location, Pledge } from '@/types';
 import { VOICE_QUOTES } from '@/constants/quotes';
 import { CardShell } from './CardShell';
 import { FinalGlobe } from './FinalGlobe';
-import { useMintedPledgeCount } from '@/hooks/usePledge';
+import { usePledgeCounts } from '@/hooks/usePledge';
 import { ENDPOINTS } from '@/constants/endpoints';
 import { useMediaMin } from '@/hooks/useBreakpoint';
 
@@ -61,7 +62,7 @@ export function FinalCard({
   userLocation,
   userPledge,
 }: FinalCardProps) {
-  const mintedPledgeCount = useMintedPledgeCount();
+  const pledgeCounts = usePledgeCounts();
   const [globeLocations, setGlobeLocations] = useState<Location[]>([]);
   const isDesktop = useMediaMin(1024);
   const closingLine = VOICE_QUOTES.final?.[voiceTone] ?? '';
@@ -174,22 +175,42 @@ export function FinalCard({
             marginBottom: 6,
           }}
         >
-          Pledges minted · live
+          Public record · live
         </div>
         <div
           style={{
-            fontFamily: FONTS.SERIF,
-            fontSize: 38,
-            lineHeight: 1,
+            display: 'inline-flex',
+            alignItems: 'baseline',
+            justifyContent: 'center',
+            gap: 10,
+            flexWrap: 'wrap',
+            fontFamily: FONTS.MONO,
+            fontSize: isDesktop ? 16 : 13,
+            lineHeight: 1.4,
             color: accent.hex,
-            letterSpacing: '-0.02em',
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
             fontVariantNumeric: 'tabular-nums',
             textShadow: `0 0 30px ${accent.glow}`,
           }}
         >
-          {mintedPledgeCount.toLocaleString()}
+          <Link
+            href="/pledges"
+            onClick={(e) => e.stopPropagation()}
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            {pledgeCounts.total.toLocaleString()} Pledges
+          </Link>
+          <span style={{ color: PALETTE.ASH_DIMMER }}>·</span>
+          <Link
+            href="/ledger"
+            onClick={(e) => e.stopPropagation()}
+            style={{ color: 'inherit', textDecoration: 'none' }}
+          >
+            {pledgeCounts.minted.toLocaleString()} On-chain
+          </Link>
         </div>
-        {userPledge?.minted && (
+        {userPledge && (
           <div
             style={{
               marginTop: 6,

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { PALETTE, FONTS, ACCENTS } from "@/constants/colors";
 import type { CardCommonProps, Location, Pledge } from "@/types";
 import { CardShell } from "./CardShell";
-import { MintedReceipt } from "./MintedReceipt";
+import { PledgeReceipt } from "./PledgeReceipt";
 import { MintButton } from "@/components/ui/MintButton";
 import { useMintPledge } from "@/hooks/usePledge";
 import { useMediaMax, useMediaMin } from "@/hooks/useBreakpoint";
@@ -41,10 +41,10 @@ export function PledgeCard({
   const [name, setName] = useState(userPledge?.name ?? "");
   const [whereFrom, setWhereFrom] = useState(userPledge?.country ?? "");
   const [writing, setWriting] = useState(false);
-  const minted = !!userPledge?.minted;
   const { mint, record, minting, error } = useMintPledge();
   const isDesktop = useMediaMin(1024);
   const isPhone = useMediaMax(767);
+  const hasRecordedPledge = !!userPledge;
 
   const pledgeText = useMemo(() => {
     if (writing) return custom;
@@ -91,7 +91,6 @@ export function PledgeCard({
         country: result.country ?? (whereFrom.trim() || null),
         minted: false,
       });
-      onNext();
     }
   };
 
@@ -103,9 +102,9 @@ export function PledgeCard({
       onNext={onNext}
       onShare={onShare}
       clickable={false}
-      hideNext={!minted}
+      hideNext={!hasRecordedPledge}
     >
-      {!minted ? (
+      {!hasRecordedPledge ? (
         <>
           <div
             style={{
@@ -445,14 +444,14 @@ export function PledgeCard({
           </div>
         </>
       ) : (
-        <MintedReceipt
+        <PledgeReceipt
           accent={accent}
           pledge={
             userPledge?.custom ??
             PRESETS.find((p) => p.id === userPledge?.choice)?.label ??
             "a small thing"
           }
-          txHash={userPledge?.txHash ?? "………"}
+          txHash={userPledge?.txHash}
           onNext={onNext}
         />
       )}

--- a/components/cards/PledgeReceipt.tsx
+++ b/components/cards/PledgeReceipt.tsx
@@ -5,14 +5,19 @@ import { PALETTE, FONTS } from "@/constants/colors";
 import type { Accent } from "@/types";
 import { stampRotate } from "@/constants/variants";
 
-type MintedReceiptProps = {
+type PledgeReceiptProps = {
   accent: Accent;
   pledge: string;
-  txHash: string;
+  txHash?: string | null;
   onNext: () => void;
 };
 
-export function MintedReceipt({ accent, pledge, txHash, onNext }: MintedReceiptProps) {
+export function PledgeReceipt({
+  accent,
+  pledge,
+  txHash,
+  onNext,
+}: PledgeReceiptProps) {
   return (
     <div
       style={{
@@ -109,12 +114,14 @@ export function MintedReceipt({ accent, pledge, txHash, onNext }: MintedReceiptP
           fontSize: 9,
           letterSpacing: "0.2em",
           color: PALETTE.ASH_DIMMER,
+          textTransform: "uppercase",
         }}
       >
-        TX · {txHash}
+        {txHash ? `TX · ${txHash}` : "Public record"}
       </div>
 
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation();
           onNext();

--- a/components/ui/ShareSheet.tsx
+++ b/components/ui/ShareSheet.tsx
@@ -35,13 +35,14 @@ const PRESET_PLEDGE_LINES: Record<string, string[]> = {
 };
 
 const SHARE_URL = `https://${SITE.domain}`;
-const LEDGER_URL = `${SHARE_URL}/ledger`;
+const LEDGER_PATH = "/ledger";
+const PLEDGES_PATH = "/pledges";
 const SHARE_TEXT = "I made a pledge to Earth.";
 const POSTER_WIDTH = 1080;
 const POSTER_HEIGHT = 1920;
 const POSTER_FILENAME = "earth-wrapped-pledge.png";
 
-type ShareActionKind = "story" | "x" | "copy-image" | "ledger";
+type ShareActionKind = "story" | "x" | "copy-image" | "record";
 
 const QUOTE_LAYOUTS = {
   hero: {
@@ -108,6 +109,8 @@ function Sheet({
   const isPhone = useMediaMax(767);
   const footerPledgeText = getFooterPledgeText(pledge);
   const xShareText = getXShareText(pledge, pledgeLines);
+  const recordUrl = pledge?.minted ? LEDGER_PATH : PLEDGES_PATH;
+  const recordLabel = pledge?.minted ? "Ledger" : "Pledges";
 
   const runAction = async (
     action: ShareActionKind,
@@ -193,10 +196,11 @@ function Sheet({
       return "Image downloaded.";
     });
 
-  const handleLedger = () =>
-    runAction("ledger", () => {
-      window.location.href = LEDGER_URL;
-      return "Opening ledger.";
+  const handleRecord = () =>
+    runAction("record", () => {
+      const tab = window.open(recordUrl, "_blank");
+      if (tab) tab.opener = null;
+      return pledge?.minted ? "Opening ledger." : "Opening pledges.";
     });
 
   return (
@@ -450,9 +454,9 @@ function Sheet({
             disabled={!!busyAction}
           />
           <ShareAction
-            label={busyAction === "ledger" ? "Opening..." : "Ledger"}
+            label={busyAction === "record" ? "Opening..." : recordLabel}
             sub="View Record"
-            onClick={handleLedger}
+            onClick={handleRecord}
             disabled={!!busyAction}
           />
         </div>
@@ -568,7 +572,8 @@ function getSignatureName(pledge?: Pledge | null) {
 
 function getFooterPledgeText(pledge: Pledge | null | undefined) {
   if (pledge?.minted) return "Minted to the ledger · yours";
-  return "Pledges minted · live";
+  if (pledge) return "Recorded in the pledges · yours";
+  return "Pledges recorded · live";
 }
 
 function getPledgeCharacterLength(pledge: Pledge | null | undefined, lines: string[]) {

--- a/hooks/usePledge.ts
+++ b/hooks/usePledge.ts
@@ -80,10 +80,6 @@ export function usePledgeCounts(pollMs = 30_000) {
   return counts;
 }
 
-export function useMintedPledgeCount(pollMs = 30_000) {
-  return usePledgeCounts(pollMs).minted;
-}
-
 function readSessionLocation(): SessionLocation | null {
   if (typeof window === "undefined") return null;
   const raw = window.localStorage.getItem(SESSION_LOCATION_KEY);

--- a/lib/db/pledges.ts
+++ b/lib/db/pledges.ts
@@ -221,6 +221,36 @@ export async function listMintedPledges(limit = 50): Promise<PledgeRow[]> {
   return rows.map(mapPledgeRow);
 }
 
+export async function listPledges(limit = 50): Promise<PledgeRow[]> {
+  const safeLimit = Math.min(Math.max(Math.trunc(limit), 1), 100);
+  const sql = getSql();
+  if (!sql) return memoryStore.slice(0, safeLimit);
+
+  const rows = (await sql`
+    SELECT
+      id,
+      pledge_text,
+      name,
+      country,
+      country_code,
+      created_at,
+      tx_hash,
+      mint_status,
+      minted_at,
+      co2_ppm_at_mint,
+      mint_network,
+      wallet_address,
+      mint_memo,
+      memo_program_id,
+      explorer_url
+    FROM pledges
+    ORDER BY created_at DESC
+    LIMIT ${safeLimit}
+  `) as PledgeDbRow[];
+
+  return rows.map(mapPledgeRow);
+}
+
 export async function cachedCountTotalPledges(): Promise<number> {
   "use cache";
   cacheTag(TOTAL_PLEDGE_COUNT_CACHE_TAG);


### PR DESCRIPTION
## Summary

Add a public `/pledges` page for all recorded pledges, keep `/ledger` minted-only, and update the pledge flow so minted and non-minted records route to the right public destination.

## Changes

- added `app/pledges/page.tsx` as a Neon-backed public page for all pledges
- kept `app/ledger/page.tsx` unchanged as the minted-only view
- added `PledgeReceipt.tsx` and removed the old minted-only receipt component
- updated the pledge confirmation flow so it supports both minted and non-minted outcomes
- moved public record links into the share sheet:
  - minted pledges link to `/ledger`
  - non-minted pledges link to `/pledges`
- updated the final card to show separate counts for:
  - total pledges
  - on-chain pledges
- added a subtle pulse to the final card’s Share button
- kept the mint and non-mint buttons themselves unchanged

## Verification

- `npm run lint` passes
- `npm test` passes
- `npm run build` passes
- `git diff --check` passes