### PR TITLE
fix(mobile): preserve pledge flow across Phantom browse handoff

### DIFF
--- a/components/MobileStory.tsx
+++ b/components/MobileStory.tsx
@@ -40,10 +40,24 @@ function getHashCardIndex() {
   return CARD_IDS.findIndex((id) => id === hashCardId);
 }
 
+function getResumeCardIndex() {
+  if (typeof window === "undefined") return -1;
+  const resumeCardId = new URL(window.location.href).searchParams.get("ewResume");
+  return CARD_IDS.findIndex((id) => id === resumeCardId);
+}
+
 function clearHashFromUrl() {
   if (typeof window === "undefined" || !window.location.hash) return;
   const { pathname, search } = window.location;
   window.history.replaceState(null, "", `${pathname}${search}`);
+}
+
+function clearResumeFromUrl() {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has("ewResume")) return;
+  url.searchParams.delete("ewResume");
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
 }
 
 export function MobileStory({ tweaks }: MobileStoryProps) {
@@ -72,6 +86,13 @@ export function MobileStory({ tweaks }: MobileStoryProps) {
       if (hashIndex >= 0) {
         setActive(hashIndex);
         clearHashFromUrl();
+        setRestoredActive(true);
+        return;
+      }
+      const resumeIndex = getResumeCardIndex();
+      if (resumeIndex >= 0) {
+        setActive(resumeIndex);
+        clearResumeFromUrl();
         setRestoredActive(true);
         return;
       }

--- a/components/cards/PledgeCard.tsx
+++ b/components/cards/PledgeCard.tsx
@@ -10,6 +10,7 @@ import { useMintPledge } from "@/hooks/usePledge";
 import { useMediaMax, useMediaMin } from "@/hooks/useBreakpoint";
 import { PLEDGE_TEXT_MAX_LENGTH, PLEDGE_TEXT_MIN_LENGTH } from "@/constants/pledge";
 import { SOLANA_NETWORK } from "@/lib/solana/mint";
+import { CARD_IDS } from "@/constants/cards";
 import {
   getWalletProviderAvailability,
   openCurrentPageInPhantom,
@@ -40,6 +41,7 @@ type PledgeDraft = {
   name: string;
   country: string;
   writing: boolean;
+  returnUrl: string | null;
 };
 
 function sanitizeDraftString(value: unknown, maxLength: number) {
@@ -61,12 +63,19 @@ function readPledgeDraftFromUrl(): PledgeDraft | null {
         : null;
     const custom = sanitizeDraftString(parsed.custom, PLEDGE_TEXT_MAX_LENGTH);
     const writing = parsed.writing === true && custom.trim().length > 0;
+    const returnUrl =
+      typeof parsed.returnUrl === "string"
+        ? new URL(parsed.returnUrl, window.location.origin)
+        : null;
+    const safeReturnUrl =
+      returnUrl?.origin === window.location.origin ? returnUrl.toString() : null;
     return {
       choice: writing ? null : choice,
       custom: writing ? custom : "",
       name: sanitizeDraftString(parsed.name, 80),
       country: sanitizeDraftString(parsed.country, 80),
       writing,
+      returnUrl: safeReturnUrl,
     };
   } catch {
     return null;
@@ -83,6 +92,20 @@ function clearPledgeDraftFromUrl() {
 
 function serializePledgeDraft(draft: PledgeDraft) {
   return JSON.stringify(draft);
+}
+
+function getNextCardId(cardId: (typeof CARD_IDS)[number]) {
+  const currentIndex = CARD_IDS.indexOf(cardId);
+  return CARD_IDS[currentIndex + 1] ?? CARD_IDS[0];
+}
+
+function buildBrowserResumeUrl(currentCardId: (typeof CARD_IDS)[number]) {
+  if (typeof window === "undefined") return null;
+  const url = new URL(window.location.href);
+  url.searchParams.delete(PHANTOM_PLEDGE_DRAFT_PARAM);
+  url.searchParams.set("ewResume", getNextCardId(currentCardId));
+  url.hash = "";
+  return url.toString();
 }
 
 export function PledgeCard({
@@ -167,6 +190,7 @@ export function PledgeCard({
           name,
           country: whereFrom,
           writing,
+          returnUrl: buildBrowserResumeUrl("pledge"),
         }),
       });
       return;
@@ -569,6 +593,7 @@ export function PledgeCard({
             "a small thing"
           }
           txHash={userPledge?.txHash}
+          returnHref={initialDraft?.returnUrl ?? null}
           onNext={onNext}
         />
       )}

--- a/components/cards/PledgeReceipt.tsx
+++ b/components/cards/PledgeReceipt.tsx
@@ -9,6 +9,7 @@ type PledgeReceiptProps = {
   accent: Accent;
   pledge: string;
   txHash?: string | null;
+  returnHref?: string | null;
   onNext: () => void;
 };
 
@@ -16,6 +17,7 @@ export function PledgeReceipt({
   accent,
   pledge,
   txHash,
+  returnHref,
   onNext,
 }: PledgeReceiptProps) {
   return (
@@ -144,6 +146,26 @@ export function PledgeReceipt({
       >
         Continue →
       </button>
+
+      {returnHref && (
+        <a
+          href={returnHref}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            marginTop: 14,
+            fontFamily: FONTS.MONO,
+            fontSize: 9,
+            letterSpacing: "0.2em",
+            textTransform: "uppercase",
+            color: PALETTE.ASH_DIM,
+            textDecoration: "none",
+          }}
+        >
+          Continue in browser ↗
+        </a>
+      )}
     </div>
   );
 }

--- a/lib/solana/wallet.ts
+++ b/lib/solana/wallet.ts
@@ -91,12 +91,12 @@ export function buildPhantomBrowseUrl(targetUrl: string, refUrl?: string) {
   return `${PHANTOM_BROWSE_BASE_URL}/${encodeURIComponent(targetUrl)}?ref=${encodeURIComponent(ref)}`;
 }
 
-export function openCurrentPageInPhantom(
+export function buildPhantomBrowseTargetUrl(
+  currentUrl: string,
   hash = "pledge",
   searchParams: Record<string, string | null | undefined> = {},
 ) {
-  if (typeof window === "undefined") return;
-  const target = new URL(window.location.href);
+  const target = new URL(currentUrl);
   for (const [key, value] of Object.entries(searchParams)) {
     if (value === null || value === undefined) {
       target.searchParams.delete(key);
@@ -105,7 +105,20 @@ export function openCurrentPageInPhantom(
     }
   }
   target.hash = hash;
-  window.location.assign(buildPhantomBrowseUrl(target.toString()));
+  return target.toString();
+}
+
+export function openCurrentPageInPhantom(
+  hash = "pledge",
+  searchParams: Record<string, string | null | undefined> = {},
+) {
+  if (typeof window === "undefined") return;
+  const targetUrl = buildPhantomBrowseTargetUrl(
+    window.location.href,
+    hash,
+    searchParams,
+  );
+  window.location.assign(buildPhantomBrowseUrl(targetUrl));
 }
 
 function logSolanaDebug(

--- a/tests/phantom-browse-url.test.ts
+++ b/tests/phantom-browse-url.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildPhantomBrowseUrl } from "../lib/solana/wallet";
+import {
+  buildPhantomBrowseTargetUrl,
+  buildPhantomBrowseUrl,
+} from "../lib/solana/wallet";
 
 test("buildPhantomBrowseUrl preserves query params and hash inside the encoded target URL", () => {
   const targetUrl =
@@ -26,4 +29,22 @@ test("buildPhantomBrowseUrl encodes nested URL characters without dropping exist
     deeplink,
     `https://phantom.app/ul/browse/${encodeURIComponent(targetUrl)}?ref=${encodeURIComponent(refUrl)}`,
   );
+});
+
+test("buildPhantomBrowseTargetUrl applies handoff params and replaces the hash", () => {
+  const targetUrl = buildPhantomBrowseTargetUrl(
+    "https://thisyear.earth/?utm_source=safari#final",
+    "pledge",
+    {
+      ewPledgeDraft: '{"choice":"vote"}',
+      removeMe: null,
+    },
+  );
+  const target = new URL(targetUrl);
+
+  assert.equal(target.origin, "https://thisyear.earth");
+  assert.equal(target.searchParams.get("utm_source"), "safari");
+  assert.equal(target.searchParams.get("ewPledgeDraft"), '{"choice":"vote"}');
+  assert.equal(target.searchParams.has("removeMe"), false);
+  assert.equal(target.hash, "#pledge");
 });


### PR DESCRIPTION
## Summary

Improve the mobile Phantom Browse flow so users can finish minting inside Phantom and then return to the browser without losing their place in the story.

## Changes

- carry a browser return URL through the Phantom Browse handoff
- derive the browser resume target from `CARD_IDS` instead of using a hardcoded card id
- make `MobileStory` consume the one-time resume hint and clear it from the URL
- keep `Continue →` available inside Phantom
- add `Continue in browser ↗` on the receipt for users who want to resume the main browser flow
- validate and restrict return URLs to same-origin only
- add regression tests around Phantom Browse URL generation and handoff behavior

## Result

- the mobile handoff into Phantom now has a clear return path
- the resume target stays aligned with the card flow if card order changes later
- cross-origin return URLs are rejected
- the flow remains honest about the Browse limitation while giving users a clean way back

## Validation

- `npm test` passes
- `npm run lint` passes
- `npm run build` passes