### PR TITLE
fix(mobile): remove brittle Phantom key fallback in Dynamic mint flow

### DIFF
--- a/hooks/useDynamicMobileMint.ts
+++ b/hooks/useDynamicMobileMint.ts
@@ -63,11 +63,22 @@ function getPhantomWalletKey(
   walletOptions: ReturnType<typeof useWalletOptions>["walletOptions"],
 ) {
   return (
-    walletOptions.find(
-      (option) =>
-        option.key.toLowerCase().includes("phantom") &&
-        option.supportedChains.includes("SOL"),
-    )?.key ?? "phantom"
+    walletOptions.find((option) => {
+      const key = option.key.toLowerCase();
+      const name = option.name.toLowerCase();
+      const group = option.group?.toLowerCase() ?? "";
+      const supportsSolana =
+        option.supportedChains.includes("SOL") ||
+        option.supportedChains.includes("SOLANA") ||
+        option.chain === "SOL";
+
+      return (
+        supportsSolana &&
+        (key.includes("phantom") ||
+          name.includes("phantom") ||
+          group.includes("phantom"))
+      );
+    })?.key ?? null
   );
 }
 
@@ -189,22 +200,27 @@ export function useDynamicMobileMint({
         }
 
         const phantomKey = getPhantomWalletKey(walletOptions);
-        const selectedWallet = await selectWalletOption(
-          phantomKey,
-          false,
-          true,
-          "SOL",
-        );
-        if (selectedWallet) {
-          await signPendingWithWallet(selectedWallet, pending);
-          return;
+        if (phantomKey) {
+          const selectedWallet = await selectWalletOption(
+            phantomKey,
+            false,
+            true,
+            "SOL",
+          );
+          if (selectedWallet) {
+            await signPendingWithWallet(selectedWallet, pending);
+            return;
+          }
         }
 
         setShowAuthFlow(true);
       } catch (e) {
-        const message =
-          e instanceof Error ? e.message : "Open Phantom to approve the mint.";
-        setError(message);
+        const message = e instanceof Error ? e.message : "";
+        if (message.includes("No wallet found with key")) {
+          setError(null);
+        } else {
+          setError(message || "Open Phantom to approve the mint.");
+        }
         setShowAuthFlow(true);
       } finally {
         setMinting(false);


### PR DESCRIPTION
## Summary

Fix the mobile Dynamic wallet flow by removing the brittle hardcoded Phantom wallet-key fallback.

## Changes

- removed the direct `"phantom"` fallback from the mobile Dynamic mint hook
- only direct-selects Phantom when Dynamic actually exposes a Solana Phantom option
- falls back to Dynamic’s normal wallet/auth flow when Phantom is not yet available
- suppresses the internal `No wallet found with key "phantom" for chain "SOL"` message so it no longer leaks into the card UI

## Validation

- `npm run lint` passes
- `npm test` passes
- `npm run build` passes