### PR TITLE
fix(wallet): switch Dynamic to connect-only redirect mode

### DIFF
--- a/components/wallet/DynamicWalletProvider.tsx
+++ b/components/wallet/DynamicWalletProvider.tsx
@@ -23,6 +23,7 @@ export function DynamicWalletProvider({ children }: DynamicWalletProviderProps) 
     <DynamicContextProvider
       settings={{
         environmentId: DYNAMIC_ENVIRONMENT_ID,
+        enableConnectOnlyFallback: true,
         initialAuthenticationMode: "connect-only",
         mobileExperience: "redirect",
         redirectUrl,


### PR DESCRIPTION
## Summary

Update the Dynamic wallet provider to use connect-only mode instead of requiring Dynamic-authenticated users.

## Changes

- set `initialAuthenticationMode: "connect-only"`
- set `enableConnectOnlyFallback: true`
- keep `mobileExperience: "redirect"`

## Validation

- `npm run lint` passes
- `npm test` passes
- `npm run build` passes