### PR TITLE
fix(mobile): stop blocking Phantom handoff on Dynamic client initiali…

### DIFF
--- a/lib/solana/dynamicClient.ts
+++ b/lib/solana/dynamicClient.ts
@@ -14,6 +14,7 @@ const DYNAMIC_ENVIRONMENT_ID =
 
 let dynamicClient: DynamicClient | null = null;
 let dynamicClientReady: Promise<DynamicClient> | null = null;
+let dynamicClientInitialized = false;
 
 function createClient() {
   return createDynamicClient({
@@ -60,8 +61,14 @@ export function ensureDynamicClientReady() {
       },
       client,
     )
-      .then(async () => {
-        await initializeClient(client);
+      .then(() => {
+        if (!dynamicClientInitialized) {
+          dynamicClientInitialized = true;
+          void initializeClient(client).catch((error) => {
+            dynamicClientInitialized = false;
+            console.error("[dynamic:init]", error);
+          });
+        }
         return client;
       })
       .catch((error) => {


### PR DESCRIPTION
## Summary

Fix the mobile mint hang where the app could stall on `Writing to ledger…` before ever opening Phantom.

## Changes

- updated `lib/solana/dynamicClient.ts` so the Phantom redirect extension is registered immediately
- stopped waiting on `initializeClient()` before returning the Dynamic client
- moved `initializeClient(client)` into a background path so the Phantom handoff is no longer blocked

## Result

- mobile mint should hand off to Phantom immediately instead of waiting on Dynamic initialization
- the old stalled state before the deeplink call is removed

## Validation

- `npm run lint` passes
- `npm run build` passes
- `npm test` passes