### PR TITLE
fix(solana): align local mobile mint flow with testnet

### DIFF
--- a/hooks/useDynamicMobileMint.ts
+++ b/hooks/useDynamicMobileMint.ts
@@ -31,6 +31,7 @@ import {
   writePendingMobileMint,
   type PendingDynamicMobileMint,
 } from "@/lib/solana/dynamicMobileMintIntent";
+import { SOLANA_NETWORK } from "@/lib/solana/mint";
 
 const PHANTOM_SOLANA_DEEPLINK_PROVIDER_KEY = "phantomsol:deepLink";
 const PHANTOM_LAUNCH_TIMEOUT_MS = 12_000;
@@ -331,6 +332,7 @@ export function useDynamicMobileMint({
 
       const pending: PendingDynamicMobileMint = {
         version: 1,
+        network: SOLANA_NETWORK,
         stage: "connect",
         pledgeText: input.pledgeText,
         metadata: input.metadata,

--- a/lib/solana/dynamicClient.ts
+++ b/lib/solana/dynamicClient.ts
@@ -10,7 +10,7 @@ import {
   completePhantomRedirect,
   detectPhantomRedirect,
 } from "@dynamic-labs-sdk/solana";
-import { SOLANA_RPC_URL } from "./mint";
+import { SOLANA_NETWORK, SOLANA_RPC_URL } from "./mint";
 
 const DYNAMIC_ENVIRONMENT_ID =
   process.env.NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID ??
@@ -43,6 +43,7 @@ function createClient() {
         if (networkData.chain !== "SOL") return networkData;
         return {
           ...networkData,
+          cluster: SOLANA_NETWORK,
           rpcUrls: {
             ...networkData.rpcUrls,
             http: [SOLANA_RPC_URL],

--- a/lib/solana/dynamicMobileMintIntent.ts
+++ b/lib/solana/dynamicMobileMintIntent.ts
@@ -1,4 +1,5 @@
 import type { PledgeMintConfirmation } from "./wallet";
+import { SOLANA_NETWORK, type SolanaNetwork } from "./mint";
 
 export const PENDING_MOBILE_MINT_KEY =
   "thisyearearth:pending-dynamic-mobile-mint";
@@ -18,6 +19,7 @@ type PendingPledgeMetadata = {
 
 export type PendingDynamicMobileMint = {
   version: 1;
+  network: SolanaNetwork;
   stage: "connect" | "sign" | "saving";
   pledgeText: string;
   metadata: PendingPledgeMetadata;
@@ -72,6 +74,7 @@ export function readPendingMobileMint(
     const stage = parsed.stage;
     if (
       parsed.version !== 1 ||
+      parsed.network !== SOLANA_NETWORK ||
       (stage !== "connect" && stage !== "sign" && stage !== "saving") ||
       typeof parsed.pledgeText !== "string" ||
       !parsed.pledgeText.trim() ||
@@ -89,6 +92,7 @@ export function readPendingMobileMint(
 
     return {
       version: 1,
+      network: SOLANA_NETWORK,
       stage,
       pledgeText: parsed.pledgeText,
       metadata: parsed.metadata ?? {},

--- a/tests/dynamic-mobile-mint-intent.test.ts
+++ b/tests/dynamic-mobile-mint-intent.test.ts
@@ -10,6 +10,7 @@ import {
   writePendingMobileMint,
   type PendingDynamicMobileMint,
 } from "../lib/solana/dynamicMobileMintIntent";
+import { SOLANA_NETWORK } from "../lib/solana/mint";
 
 class MemoryStorage implements Pick<Storage, "getItem" | "setItem" | "removeItem"> {
   private values = new Map<string, string>();
@@ -34,6 +35,7 @@ function makePending(
 ): PendingDynamicMobileMint {
   return {
     version: 1,
+    network: SOLANA_NETWORK,
     stage: "connect",
     pledgeText: "Vote climate",
     metadata: {
@@ -61,6 +63,20 @@ test("pending mobile mint intent round-trips through storage", () => {
   assert.equal(stored?.choice, pending.choice);
   assert.equal(stored?.custom, pending.custom);
   assert.equal(stored?.createdAt, pending.createdAt);
+});
+
+test("pending mobile mint intent from another Solana network is cleared", () => {
+  const storage = new MemoryStorage();
+  storage.setItem(
+    PENDING_MOBILE_MINT_KEY,
+    JSON.stringify({
+      ...makePending(),
+      network: SOLANA_NETWORK === "testnet" ? "devnet" : "testnet",
+    }),
+  );
+
+  assert.equal(readPendingMobileMint({ storage, now: NOW }), null);
+  assert.equal(storage.getItem(PENDING_MOBILE_MINT_KEY), null);
 });
 
 test("expired pending mobile mint intent is cleared and ignored", () => {


### PR DESCRIPTION
## Summary

Align the local mobile mint flow with Solana Testnet instead of Devnet.

## Changes

- updated local Solana env config to use:
  - `NEXT_PUBLIC_SOLANA_NETWORK=testnet`
  - `NEXT_PUBLIC_SOLANA_RPC_URL=https://api.testnet.solana.com`
- updated the Dynamic Solana client setup to use the configured cluster and RPC
- updated pending mobile mint state handling so stale intent from another network is cleared
- added test coverage for cross-network pending mint cleanup

## Validation

- `npm run lint` passes
- `npm run build` passes
- `npm test` passes