### PR TITLE
fix(mobile): restore Phantom callback tab close handling

### DIFF
--- a/lib/solana/dynamicClient.ts
+++ b/lib/solana/dynamicClient.ts
@@ -3,6 +3,7 @@
 import {
   createDynamicClient,
   initializeClient,
+  onceEvent,
   type DynamicClient,
 } from "@dynamic-labs-sdk/client";
 import {
@@ -19,6 +20,12 @@ const DYNAMIC_ENVIRONMENT_ID =
 let dynamicClient: DynamicClient | null = null;
 let dynamicClientReady: Promise<DynamicClient> | null = null;
 let dynamicClientInitialized = false;
+
+declare global {
+  interface DynamicEvents {
+    phantomRedirectCloseTab: (args: Record<string, never>) => void;
+  }
+}
 
 function getCurrentUrl() {
   return new URL(window.location.href);
@@ -105,6 +112,13 @@ export async function completePendingPhantomRedirect(client: DynamicClient) {
   const currentUrl = getCurrentUrl();
   const isRedirect = await detectPhantomRedirect({ url: currentUrl }, client);
   if (!isRedirect) return false;
+  onceEvent(
+    {
+      event: "phantomRedirectCloseTab",
+      listener: () => window.close(),
+    },
+    client,
+  );
   await completePhantomRedirect({ url: currentUrl }, client);
   return true;
 }


### PR DESCRIPTION
## Summary

Fix the Phantom mobile callback tab flow so the redirect tab closes after the redirect completes.

## Changes

- updated `lib/solana/dynamicClient.ts`
- registers `phantomRedirectCloseTab` before completing a pending Phantom redirect
- uses `window.close()` for the callback tab close listener
- leaves the existing mint, confirmation, and receipt flow unchanged

## Validation

- `npm run lint` passes
- `npm run build` passes
- `npm test` passes